### PR TITLE
Automate Drizzle migrations at server start

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,7 +4,7 @@ dotenv.config();
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
-import { initializeDatabase, createDefaultUsers } from "./database-setup";
+import { initializeDatabase, createDefaultUsers, runMigrations } from "./database-setup";
 import { setupSecurity } from "./security";
 import path from "path";
 
@@ -76,6 +76,16 @@ app.use((req, res, next) => {
   // ALWAYS serve the app on port 5000
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
+  
+  // Run database migrations before starting server
+  try {
+    await runMigrations();
+    log("✅ Database migrations completed successfully");
+  } catch (error) {
+    log("⚠️ Database migration failed:", error);
+    // Continue server startup - fallback handling is in initializeDatabase
+  }
+  
   // Initialize database before starting server
   await initializeDatabase();
   await createDefaultUsers();


### PR DESCRIPTION
Add automatic Drizzle migration on server start to ensure the database schema is always up-to-date.

Previously, migrations were implicitly called within `initializeDatabase`. This PR makes the call explicit before server startup, adds robust error handling, and correctly resolves the migration path for both development and production environments.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-762919fe-7f26-416f-a3b8-909dc1728e55) · [Cursor](https://cursor.com/background-agent?bcId=bc-762919fe-7f26-416f-a3b8-909dc1728e55)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)