### PR TITLE
Build and deploy rest-express project

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -167,7 +167,6 @@ export function useChat() {
         withCredentials: false, // تبسيط الأمان
         
         // إعدادات ping/pong
-        timeout: 30000,
         // pingInterval: 20000, // إزالة هذا لأنه غير مدعوم في socket.io-client
       });
       

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp -r migrations dist/",
+    "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && cp -r migrations dist/ && cp -r shared dist/",
     "start": "NODE_ENV=production node dist/index.js",
     "postbuild": "echo '✅ البناء مكتمل'",
     "deploy": "npm run build",

--- a/server/enhanced-moderation.ts
+++ b/server/enhanced-moderation.ts
@@ -1,5 +1,5 @@
 import { storage } from './storage';
-import type { User } from '@shared/schema';
+import type { User } from '../../shared/schema';
 
 export interface EnhancedModerationAction {
   id: string;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,7 +3,7 @@ import { createServer, type Server } from "http";
 import { Server as IOServer, Socket } from "socket.io";
 import { storage } from "./storage";
 import { setupDownloadRoute } from "./download-route";
-import { insertUserSchema, insertMessageSchema } from "@shared/schema";
+import { insertUserSchema, insertMessageSchema } from "../../shared/schema";
 import { spamProtection } from "./spam-protection";
 import { moderationSystem } from "./moderation";
 import { sanitizeInput, validateMessageContent, checkIPSecurity, authLimiter, messageLimiter } from "./security";

--- a/server/services/AuthService.ts
+++ b/server/services/AuthService.ts
@@ -1,6 +1,6 @@
 import { SecurityManager } from '../auth/security';
 import type { IStorage } from '../storage';
-import type { InsertUser, User } from '@shared/schema';
+import type { InsertUser, User } from '../../shared/schema';
 
 /**
  * خدمة المصادقة المحسنة مع الأمان

--- a/server/services/pointsService.ts
+++ b/server/services/pointsService.ts
@@ -5,7 +5,7 @@ import {
   checkLevelUp, 
   DEFAULT_POINTS_CONFIG,
   DEFAULT_LEVELS
-} from '@shared/points-system';
+} from '../../shared/points-system';
 
 export class PointsService {
   // إضافة نقاط لمستخدم


### PR DESCRIPTION
Fix module resolution for `@shared` imports and resolve client-side duplicate key warning.

The `@shared` path alias was not correctly resolved by esbuild during the production build, leading to `ERR_MODULE_NOT_FOUND`. This PR updates imports to relative paths and ensures the `shared` directory is copied to the build output. Additionally, a duplicate `timeout` key in `useChat.ts` was removed to clear a build warning.

---

[Open in Web](https://www.cursor.com/agents?id=bc-b1700cfd-3112-4e88-8de3-dac8604b740b) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b1700cfd-3112-4e88-8de3-dac8604b740b)