### PR TITLE
Fix room display and access issues

### DIFF
--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -12,12 +12,6 @@ export default function ChatPage() {
   const [selectedRoomId, setSelectedRoomId] = useState<string | null>(null);
   const chat = useChat();
 
-  // الغرف المتاحة
-  const rooms: ChatRoom[] = [
-    { id: 'general', name: 'الدردشة العامة', description: 'الغرفة الرئيسية للدردشة', isDefault: true, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 12, icon: '' },
-    { id: 'music', name: 'أغاني وسهر', description: 'غرفة للموسيقى والترفيه', isDefault: false, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 8, icon: '' }
-  ];
-
   const handleUserLogin = (user: ChatUser) => {
     chat.connect(user);
     setShowWelcome(false);
@@ -42,7 +36,7 @@ export default function ChatPage() {
         <WelcomeScreen onUserLogin={handleUserLogin} />
       ) : showRoomSelector ? (
         <RoomSelector 
-          rooms={rooms} 
+          rooms={chat.rooms} 
           currentUser={chat.currentUser!} 
           onRoomSelect={handleRoomSelect} 
         />


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fetch rooms dynamically from the server and improve real-time user count updates to fix display and joining issues.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the `chat.tsx` page used a hardcoded list of rooms, preventing newly created rooms from appearing. This PR updates `chat.tsx` to use rooms fetched via the `useChat` hook. Additionally, it enhances `useChat.ts` to ensure `fetchRooms` is called upon user login and when users join/leave rooms, and improves the `joinRoom` logic to interact correctly with the backend API and update user counts in real-time.

---
<a href="https://cursor.com/background-agent?bcId=bc-66ac9845-f36e-4efd-96d4-798ba2f31b90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-66ac9845-f36e-4efd-96d4-798ba2f31b90">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>