### PR TITLE
Fix duplicate symbol declaration in chat interface

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -297,12 +297,6 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     setSelectedPrivateUser(null);
   }, []);
 
-  const handleReportUser = useCallback((user: ChatUser, messageContent: string, messageId: number) => {
-    setReportedUser(user);
-    setReportedMessage({ content: messageContent, id: messageId });
-    setShowReportModal(true);
-  }, []);
-
   const handleAddFriend = async (user: ChatUser) => {
     if (!chat.currentUser) return;
     


### PR DESCRIPTION
Remove duplicate `handleReportUser` declaration to fix build error.

The `ChatInterface.tsx` file had two `handleReportUser` declarations. The `useCallback` version with required parameters was removed, keeping the regular function with optional parameters, as it supports all call sites and includes a necessary `closeUserPopup()` call.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a9b5752-22f8-4291-9725-0d0436a8c15c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a9b5752-22f8-4291-9725-0d0436a8c15c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>