### PR TITLE
Build project with esbuild error

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -108,7 +108,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
     case 'SET_PUBLIC_MESSAGES':
       return { ...state, publicMessages: action.payload };
     
-    case 'ADD_PRIVATE_MESSAGE':
+    case 'ADD_PRIVATE_MESSAGE': {
       const { userId, message } = action.payload;
       return {
         ...state,
@@ -117,6 +117,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
           [userId]: [...(state.privateConversations[userId] || []), message]
         }
       };
+    }
     
     case 'SET_CONNECTION_STATUS':
       return { ...state, isConnected: action.payload };
@@ -139,15 +140,16 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         notifications: [...state.notifications, action.payload] 
       };
     
-    case 'SET_ROOM':
+    case 'SET_ROOM': {
       const currentMessages = state.roomMessages[action.payload] || [];
       return { 
         ...state, 
         currentRoomId: action.payload,
         publicMessages: currentMessages
       };
+    }
     
-    case 'ADD_ROOM_MESSAGE':
+    case 'ADD_ROOM_MESSAGE': {
       const { roomId, message } = action.payload;
       const newRoomMessages = { ...state.roomMessages };
       
@@ -172,6 +174,7 @@ function chatReducer(state: ChatState, action: ChatAction): ChatState {
         roomMessages: newRoomMessages,
         publicMessages: updatedPublicMessages
       };
+    }
     
     case 'SET_SHOW_KICK_COUNTDOWN':
       return { ...state, showKickCountdown: action.payload };


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Wrap `switch` cases in `useChat.ts` with block scopes to resolve a "symbol already declared" build error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The error was caused by duplicate `message` variable declarations in different `case` statements within the same `switch` block. Wrapping each case in curly braces creates a new lexical scope, preventing variable name collisions.

---
<a href="https://cursor.com/background-agent?bcId=bc-c562cc02-d7a4-4c74-a813-1a85c228b5fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c562cc02-d7a4-4c74-a813-1a85c228b5fd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>