### PR TITLE
Log missing user id on join room

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -270,10 +270,11 @@ export function useChat() {
       dispatch({ type: 'SET_CONNECTION_ERROR', payload: null });
       
       // إرسال بيانات المصادقة
-      socket.current?.emit('auth', {
+      socket.current?.emit('authenticate', {
         userId: user.id,
         username: user.username,
-        userType: user.userType
+        userType: user.userType,
+        authType: 'registered'
       });
     });
 


### PR DESCRIPTION
Align client authentication event name with server expectation to resolve undefined user IDs.

The client was emitting an `auth` event, but the server was listening for `authenticate`, causing `userId` and `username` to be undefined in the session and preventing proper room joining. This change ensures correct user identification.

---
<a href="https://cursor.com/background-agent?bcId=bc-071d20f8-d501-4638-b077-e62760112497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-071d20f8-d501-4638-b077-e62760112497">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

