### PR TITLE
Fix user list count after user joins

### DIFF
--- a/test-users-fix.js
+++ b/test-users-fix.js
@@ -1,0 +1,53 @@
+const io = require('socket.io-client');
+
+console.log('🧪 اختبار إصلاح قائمة المستخدمين...');
+
+// الاتصال بالخادم المحلي
+const socket = io('https://abd-ylo2.onrender.com', {
+  transports: ['websocket']
+});
+
+socket.on('connect', () => {
+  console.log('✅ تم الاتصال بنجاح');
+  
+  // تسجيل الدخول كضيف
+  socket.emit('auth', {
+    userId: 241,
+    username: 'قصب',
+    userType: 'guest'
+  });
+});
+
+socket.on('authenticated', (data) => {
+  console.log('✅ تمت المصادقة:', data);
+  
+  // طلب قائمة المستخدمين بعد ثانية واحدة
+  setTimeout(() => {
+    console.log('📡 طلب قائمة المستخدمين...');
+    socket.emit('requestOnlineUsers');
+  }, 1000);
+});
+
+socket.on('message', (data) => {
+  if (data.type === 'onlineUsers') {
+    console.log(`👥 قائمة المستخدمين المتصلين: ${data.users.length} مستخدم`);
+    if (data.users.length > 0) {
+      console.log('أسماء المستخدمين:', data.users.map(u => u.username).join(', '));
+      console.log('✅ الإصلاح يعمل بنجاح!');
+    } else {
+      console.log('❌ لا يزال هناك مشكلة - لم يتم جلب أي مستخدمين');
+    }
+    process.exit(0);
+  }
+});
+
+socket.on('error', (error) => {
+  console.error('❌ خطأ:', error);
+  process.exit(1);
+});
+
+// إنهاء الاختبار بعد 10 ثوان
+setTimeout(() => {
+  console.log('⏱️ انتهى وقت الاختبار');
+  process.exit(0);
+}, 10000);

--- a/إصلاح-قائمة-المستخدمين.md
+++ b/إصلاح-قائمة-المستخدمين.md
@@ -1,0 +1,52 @@
+# إصلاح مشكلة قائمة المستخدمين الفارغة
+
+## المشكلة
+بعد تسجيل الدخول، كانت قائمة المستخدمين المتصلين تظهر فارغة (0 مستخدمين) رغم أن المستخدم متصل بنجاح.
+
+## السبب
+كان هناك معالجان مختلفان للمصادقة:
+1. `socket.on('authenticate')` - يضيف المستخدم إلى `connectedUsers`
+2. `socket.on('auth')` - **لا يضيف** المستخدم إلى `connectedUsers` ❌
+
+الكود كان يستخدم `auth` بدلاً من `authenticate`، لذلك لم يتم إضافة المستخدمين إلى قائمة المتصلين.
+
+## الحل
+تم إضافة الكود المفقود في معالج `auth` لإضافة المستخدم إلى `connectedUsers`:
+
+```typescript
+// إضافة المستخدم لقائمة المتصلين الفعليين
+connectedUsers.set(user.id, {
+  user: user,
+  socketId: socket.id,
+  room: 'general',
+  lastSeen: new Date()
+});
+```
+
+وأيضاً تم تحديث الغرفة في `connectedUsers` عند الانضمام للغرف:
+
+```typescript
+// تحديث الغرفة في connectedUsers
+if (connectedUsers.has(user.id)) {
+  const userConnection = connectedUsers.get(user.id)!;
+  userConnection.room = currentRoom;
+  connectedUsers.set(user.id, userConnection);
+}
+```
+
+## التغييرات
+1. **السطر 1644**: إضافة المستخدم إلى `connectedUsers` بعد المصادقة
+2. **السطر 1683**: تحديث الغرفة في `connectedUsers` عند الانضمام للغرف
+3. **السطر 1697**: تحديث الغرفة في `connectedUsers` في حالة الخطأ
+
+## النتيجة
+الآن عند تسجيل الدخول:
+- ✅ يتم إضافة المستخدم إلى قائمة المتصلين
+- ✅ يتم تحديث الغرفة بشكل صحيح
+- ✅ تظهر قائمة المستخدمين بشكل صحيح
+
+## اختبار الإصلاح
+يمكنك تشغيل ملف الاختبار:
+```bash
+node test-users-fix.js
+```


### PR DESCRIPTION
Fixes online user list showing zero users after login.

The `auth` event handler was not adding authenticated users to the `connectedUsers` map, which is essential for tracking online users. This PR ensures users are added upon authentication and their room information is correctly updated within `connectedUsers` when joining rooms or defaulting to 'general'.

---
<a href="https://cursor.com/background-agent?bcId=bc-e96b7654-4c84-4921-95cd-65c67bf5c878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e96b7654-4c84-4921-95cd-65c67bf5c878">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

