### PR TITLE
Investigate user status display bug

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -497,17 +497,12 @@ export function useChat() {
               // دون إرسال طلبات إضافية
             }
             
-            // طلب قائمة محدثة من المستخدمين - مع تقليل الطلبات المتكررة
-            setTimeout(() => {
-              if (socket.current?.connected && !isLoadingMessages.current) {
-                socket.current.emit('requestOnlineUsers');
-                isLoadingMessages.current = true;
-                // منع الطلبات المتكررة لمدة 5 ثوان
-                setTimeout(() => {
-                  isLoadingMessages.current = false;
-                }, 5000);
-              }
-            }, 3000); // زيادة التأخير لتجنب الطلبات المفرطة
+            // طلب قائمة محدثة من المستخدمين - بدون تأخير إضافي وبنفس حماية التكرار
+            if (socket.current?.connected && !isLoadingMessages.current) {
+              socket.current.emit('requestOnlineUsers');
+              isLoadingMessages.current = true;
+              setTimeout(() => { isLoadingMessages.current = false; }, 3000);
+            }
             break;
             
           default:
@@ -524,8 +519,8 @@ export function useChat() {
     dispatch({ type: 'SET_CURRENT_USER', payload: user });
     dispatch({ type: 'SET_LOADING', payload: true });
     
-    // إضافة المستخدم الحالي للقائمة فوراً
-    dispatch({ type: 'SET_ONLINE_USERS', payload: [user] });
+    // عدم تعيين قائمة مؤقتة لتفادي الوميض؛ ستأتي القائمة من الخادم حسب الغرفة
+    // dispatch({ type: 'SET_ONLINE_USERS', payload: [user] });
 
     try {
       // تنظيف شامل للاتصال السابق لتجنب التضارب

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1907,8 +1907,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
               })
             );
             
-            // إرسال قائمة المستخدمين المحدثة لجميع العملاء عبر رسالة موحدة
-            io.emit('message', { type: 'onlineUsers', users: usersWithStatus });
+            // إزالة البث العالمي لقائمة المستخدمين لتفادي وميض القائمة
+            // سيتم إرسال قوائم المستخدمين حسب الغرفة فقط عبر أحداث roomJoined/room switches وrequestOnlineUsers
             break;
 
           case 'publicMessage':


### PR DESCRIPTION
Removes global online user list broadcast and temporary client-side list to resolve user list flickering.

The flickering occurred because the client received conflicting `onlineUsers` lists: an initial global broadcast from the database (potentially including offline users) and later, more accurate room-specific lists from actual connected users. This change unifies the source of truth to only use actual connected users per room.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d48f7d9-f21f-447d-adcd-2d79acffc19f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9d48f7d9-f21f-447d-adcd-2d79acffc19f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

