### PR TITLE
Fix friend request accept error

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2739,41 +2739,41 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { userId } = req.body;
       
       const request = await storage.getFriendRequestById(requestId);
-      if (!request || request.receiverId !== userId) {
+      if (!request || request.friendId !== userId) {
         return res.status(403).json({ error: "غير مسموح" });
       }
 
       // قبول طلب الصداقة وإضافة الصداقة
       await storage.acceptFriendRequest(requestId);
-      await storage.addFriend(request.senderId, request.receiverId);
+      await storage.addFriend(request.userId, request.friendId);
       
       // الحصول على بيانات المستخدمين
       const receiver = await storage.getUser(userId);
-      const sender = await storage.getUser(request.senderId);
+      const sender = await storage.getUser(request.userId);
       
       // إرسال إشعار WebSocket لتحديث قوائم الأصدقاء
       broadcast({
         type: 'friendAdded',
-        targetUserId: request.senderId,
-        friendId: request.receiverId,
+        targetUserId: request.userId,
+        friendId: request.friendId,
         friendName: receiver?.username
       });
       
       broadcast({
         type: 'friendAdded', 
-        targetUserId: request.receiverId,
-        friendId: request.senderId,
+        targetUserId: request.friendId,
+        friendId: request.userId,
         friendName: sender?.username
       });
       broadcast({
         type: 'friendRequestAccepted',
-        targetUserId: request.senderId,
+        targetUserId: request.userId,
         senderName: receiver?.username
       });
 
       // إنشاء إشعار حقيقي في قاعدة البيانات
       await storage.createNotification({
-        userId: request.senderId,
+        userId: request.userId,
         type: 'friendAccepted',
         title: '✅ تم قبول طلب الصداقة',
         message: `قبل ${receiver?.username} طلب صداقتك`,
@@ -2794,7 +2794,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { userId } = req.body;
       
       const request = await storage.getFriendRequestById(requestId);
-      if (!request || request.receiverId !== userId) {
+      if (!request || request.friendId !== userId) {
         return res.status(403).json({ error: "غير مسموح" });
       }
 
@@ -2812,7 +2812,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { userId } = req.body;
       
       const request = await storage.getFriendRequestById(requestId);
-      if (!request || request.senderId !== userId) {
+      if (!request || request.userId !== userId) {
         return res.status(403).json({ error: "غير مسموح" });
       }
 
@@ -2830,7 +2830,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const { userId } = req.body;
       
       const request = await storage.getFriendRequestById(requestId);
-      if (!request || request.receiverId !== userId) {
+      if (!request || request.friendId !== userId) {
         return res.status(403).json({ error: "غير مسموح" });
       }
 


### PR DESCRIPTION
Corrected friend request field names in backend endpoints to resolve 400 Bad Request errors.

The `Friend` object returned by `getFriendRequestById` uses `userId` (for the sender) and `friendId` (for the receiver), but the backend logic was incorrectly referencing `senderId` and `receiverId`. This PR updates the `accept`, `decline`, `cancel`, and `ignore` friend request endpoints to use the correct field names, ensuring proper validation and friend management.

---
<a href="https://cursor.com/background-agent?bcId=bc-e200c77c-69ee-4321-8726-b69d12415077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e200c77c-69ee-4321-8726-b69d12415077">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

