### PR TITLE
Investigate friend request acceptance error

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -123,8 +123,7 @@ export default function FriendsTabPanel({
     try {
       await apiRequest(`/api/friend-requests/${requestId}/accept`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: currentUser?.id })
+        body: { userId: currentUser?.id }
       });
       
       toast({
@@ -151,8 +150,7 @@ export default function FriendsTabPanel({
     try {
       await apiRequest(`/api/friend-requests/${requestId}/decline`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ userId: currentUser?.id })
+        body: { userId: currentUser?.id }
       });
       
       toast({


### PR DESCRIPTION
Fixes "body stream already read" error by preventing double-reading of response body and correcting request body serialization for friend requests.

The "body stream already read" error occurred because the error handling function `throwIfResNotOk` attempted to read the response body twice when an API call failed. This error path was triggered by friend request actions sending a double-stringified request body, which caused the server to return an error.

---
<a href="https://cursor.com/background-agent?bcId=bc-ae548c6d-e4d5-4477-be33-cb5658e34c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ae548c6d-e4d5-4477-be33-cb5658e34c49">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

