### PR TITLE
Fix owner tab supervisor list and remove supervision

### DIFF
--- a/client/src/components/chat/OwnerAdminPanel.tsx
+++ b/client/src/components/chat/OwnerAdminPanel.tsx
@@ -140,23 +140,25 @@ export default function OwnerAdminPanel({
     if (!currentUser) return;
     
     try {
-      const response = await apiRequest('/api/admin/users/promote', {
+      const response = await apiRequest('/api/moderation/promote', {
         method: 'POST',
         body: {
-          userId: targetUser.id,
-          newRole: 'member',
-          promoterId: currentUser.id
+          moderatorId: currentUser.id,
+          targetUserId: targetUser.id,
+          newRole: 'member'
         }
       });
       
       toast({
         title: 'تم إلغاء الإشراف',
-        description: `تم إلغاء إشراف ${targetUser.username}`,
+        description: `تم إلغاء إشراف ${targetUser.username} بنجاح`,
         variant: 'default'
       });
       
+      // تحديث قائمة المشرفين فوراً
       fetchStaffMembers();
     } catch (error) {
+      console.error('Error demoting user:', error);
       toast({
         title: 'خطأ',
         description: 'فشل في إلغاء الإشراف',

--- a/client/src/components/chat/OwnerAdminPanel.tsx
+++ b/client/src/components/chat/OwnerAdminPanel.tsx
@@ -101,27 +101,36 @@ export default function OwnerAdminPanel({
   const fetchStaffMembers = async () => {
     setLoading(true);
     try {
-      // جلب جميع المستخدمين وتصفية الإداريين
-      const allUsers = onlineUsers.concat(
-        // يمكن إضافة مستخدمين آخرين من قاعدة البيانات
-      );
+      // جلب جميع المستخدمين من قاعدة البيانات (متصلين وغير متصلين)
+      const response = await apiRequest('/api/users', {
+        method: 'GET'
+      });
       
-      const staff = allUsers.filter(user => 
+      const allUsers = response.users || [];
+      
+      // تصفية المشرفين والإداريين
+      const staff = allUsers.filter((user: any) => 
         user.userType === 'moderator' || 
         user.userType === 'admin' || 
         user.userType === 'owner'
-      ).map(user => ({
+      ).map((user: any) => ({
         id: user.id,
         username: user.username,
         userType: user.userType as 'moderator' | 'admin' | 'owner',
         profileImage: user.profileImage,
         joinDate: user.joinDate,
         lastSeen: user.lastSeen,
-        isOnline: true
+        isOnline: onlineUsers.some(onlineUser => onlineUser.id === user.id)
       }));
+      
       setStaffMembers(staff);
     } catch (error) {
       console.error('Error fetching staff:', error);
+      toast({
+        title: 'خطأ',
+        description: 'فشل في جلب قائمة المشرفين',
+        variant: 'destructive'
+      });
     } finally {
       setLoading(false);
     }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -693,27 +693,42 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const success = await moderationSystem.promoteUser(moderatorId, targetUserId, newRole);
       
       if (success) {
-        console.log(`[PROMOTE_ENDPOINT] نجحت الترقية`);
+        console.log(`[PROMOTE_ENDPOINT] نجحت العملية`);
         
         // إرسال إشعار عبر WebSocket
         const target = await storage.getUser(targetUserId);
         const moderator = await storage.getUser(moderatorId);
         
         if (target && moderator) {
-          const promotionMessage = {
+          let notificationMessage = '';
+          let successMessage = '';
+          
+          if (newRole === 'member') {
+            // إزالة الإشراف
+            notificationMessage = `⚠️ تم إلغاء إشراف ${target.username} بواسطة ${moderator.username}`;
+            successMessage = "تم إلغاء الإشراف بنجاح";
+          } else {
+            // ترقية
+            notificationMessage = `🎉 تم ترقية ${target.username} إلى ${newRole === 'admin' ? 'إدمن' : 'مشرف'} بواسطة ${moderator.username}`;
+            successMessage = "تم ترقية المستخدم بنجاح";
+          }
+          
+          const systemMessage = {
             type: 'systemNotification',
-            message: `🎉 تم ترقية ${target.username} إلى ${newRole === 'admin' ? 'إدمن' : 'مشرف'} بواسطة ${moderator.username}`,
+            message: notificationMessage,
             timestamp: new Date().toISOString()
           };
           
-          broadcast(promotionMessage);
+          broadcast(systemMessage);
           console.log(`[PROMOTE_ENDPOINT] تم إرسال إشعار WebSocket`);
+          
+          res.json({ message: successMessage });
+        } else {
+          res.json({ message: newRole === 'member' ? "تم إلغاء الإشراف بنجاح" : "تم ترقية المستخدم بنجاح" });
         }
-        
-        res.json({ message: "تم ترقية المستخدم بنجاح" });
       } else {
-        console.log(`[PROMOTE_ENDPOINT] فشلت الترقية`);
-        res.status(400).json({ error: "فشل في ترقية المستخدم" });
+        console.log(`[PROMOTE_ENDPOINT] فشلت العملية`);
+        res.status(400).json({ error: newRole === 'member' ? "فشل في إلغاء الإشراف" : "فشل في ترقية المستخدم" });
       }
     } catch (error) {
       console.error("[PROMOTE_ENDPOINT] خطأ في ترقية المستخدم:", error);
@@ -3071,27 +3086,42 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const success = await moderationSystem.promoteUser(moderatorId, targetUserId, newRole);
       
       if (success) {
-        console.log(`[PROMOTE_ENDPOINT] نجحت الترقية`);
+        console.log(`[PROMOTE_ENDPOINT] نجحت العملية`);
         
         // إرسال إشعار عبر WebSocket
         const target = await storage.getUser(targetUserId);
         const moderator = await storage.getUser(moderatorId);
         
         if (target && moderator) {
-          const promotionMessage = {
+          let notificationMessage = '';
+          let successMessage = '';
+          
+          if (newRole === 'member') {
+            // إزالة الإشراف
+            notificationMessage = `⚠️ تم إلغاء إشراف ${target.username} بواسطة ${moderator.username}`;
+            successMessage = "تم إلغاء الإشراف بنجاح";
+          } else {
+            // ترقية
+            notificationMessage = `🎉 تم ترقية ${target.username} إلى ${newRole === 'admin' ? 'إدمن' : 'مشرف'} بواسطة ${moderator.username}`;
+            successMessage = "تم ترقية المستخدم بنجاح";
+          }
+          
+          const systemMessage = {
             type: 'systemNotification',
-            message: `🎉 تم ترقية ${target.username} إلى ${newRole === 'admin' ? 'إدمن' : 'مشرف'} بواسطة ${moderator.username}`,
+            message: notificationMessage,
             timestamp: new Date().toISOString()
           };
           
-          broadcast(promotionMessage);
+          broadcast(systemMessage);
           console.log(`[PROMOTE_ENDPOINT] تم إرسال إشعار WebSocket`);
+          
+          res.json({ message: successMessage });
+        } else {
+          res.json({ message: newRole === 'member' ? "تم إلغاء الإشراف بنجاح" : "تم ترقية المستخدم بنجاح" });
         }
-        
-        res.json({ message: "تم ترقية المستخدم بنجاح" });
       } else {
-        console.log(`[PROMOTE_ENDPOINT] فشلت الترقية`);
-        res.status(400).json({ error: "فشل في ترقية المستخدم" });
+        console.log(`[PROMOTE_ENDPOINT] فشلت العملية`);
+        res.status(400).json({ error: newRole === 'member' ? "فشل في إلغاء الإشراف" : "فشل في ترقية المستخدم" });
       }
     } catch (error) {
       console.error("[PROMOTE_ENDPOINT] خطأ في ترقية المستخدم:", error);


### PR DESCRIPTION
Fixes the owner panel to display all staff members and enables proper demotion of moderators by extending the promotion system.

The admin list previously only fetched online users, leading to an incomplete view of staff. Additionally, the demotion functionality was broken due to an incorrect API endpoint and a server-side `promoteUser` function that only supported promotion from 'member' to higher roles, not demotion to 'member'. This PR updates the client to fetch all users and modifies the server-side `promoteUser` to correctly handle demotion to 'member' role.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4d0f7f4-de6b-4b73-8724-56fa4864374f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4d0f7f4-de6b-4b73-8724-56fa4864374f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

