### PR TITLE
Fix broadcast room host count logic

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -710,6 +710,27 @@ export const storage: LegacyStorage = {
     }
   },
 
+  // تعيين/تحديث مضيف غرفة البث
+  async setRoomHost(roomId: string, hostId: number | null): Promise<boolean> {
+    try {
+      const { db, dbType } = await import('./database-adapter');
+      if (!db) return false;
+
+      if (dbType === 'postgresql') {
+        const { rooms } = await import('../shared/schema');
+        const { eq } = await import('drizzle-orm');
+        await (db as any).update(rooms).set({ hostId }).where(eq((rooms as any).id, roomId as any));
+      } else if (dbType === 'sqlite') {
+        (db as any).run?.("UPDATE rooms SET host_id = ? WHERE id = ?", [hostId, roomId]);
+      }
+
+      return true;
+    } catch (error) {
+      console.error('Error setting room host:', error);
+      return false;
+    }
+  },
+
   // دالة مساعدة للتحقق من صحة غرفة البث - محدثة للسماح للمشرفين والإدمن
   async validateBroadcastRoom(roomId: string, actionBy?: number) {
     const status = databaseService.getStatus();


### PR DESCRIPTION
Implement automatic host assignment and reassignment for broadcast rooms.

Previously, broadcast rooms could have a `null` host, leading to display issues. This change ensures that the first user with owner, admin, or moderator privileges who joins a broadcast room is automatically assigned as the host. It also handles reassigning the host if the current host leaves or disconnects, ensuring a host is always present if a privileged user is in the room.

---
<a href="https://cursor.com/background-agent?bcId=bc-7c3570d8-bf21-4cfd-bb32-640ee0436251">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7c3570d8-bf21-4cfd-bb32-640ee0436251">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

