### PR TITLE
Fix room query error

### DIFF
--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -600,7 +600,7 @@ export class DatabaseService {
         return await (this.db as any)
           .select()
           .from(pgSchema.rooms)
-          .where(or(isNull(pgSchema.rooms.deletedAt), eq(pgSchema.rooms.deletedAt as any, null as any)))
+          .where(isNull(pgSchema.rooms.deletedAt))
           .orderBy(asc(pgSchema.rooms.name));
       } else {
         return await (this.db as any).select().from(sqliteSchema.rooms).orderBy(asc(sqliteSchema.rooms.name));

--- a/server/services/messageService.ts
+++ b/server/services/messageService.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and, or } from "drizzle-orm";
+import { eq, desc, and, or, isNull } from "drizzle-orm";
 import { db } from "../database-adapter";
 import { messages, users, type Message, type InsertMessage } from "../../shared/schema";
 
@@ -40,7 +40,7 @@ export class MessageService {
         })
         .from(messages)
         .leftJoin(users, eq(messages.senderId, users.id))
-        .where(and(eq(messages.isPrivate, false), eq(messages.deletedAt as any, null as any)))
+        .where(and(eq(messages.isPrivate, false), isNull(messages.deletedAt)))
         .orderBy(desc(messages.timestamp))
         .limit(limit);
 
@@ -99,10 +99,10 @@ export class MessageService {
             or(
               and(eq(messages.senderId, userId1), eq(messages.receiverId, userId2)),
               and(eq(messages.senderId, userId2), eq(messages.receiverId, userId1))
-            )
+            ),
+            isNull(messages.deletedAt)
           )
         )
-        .where(and(eq(messages.isPrivate, true), eq(messages.deletedAt as any, null as any)))
         .orderBy(desc(messages.timestamp))
         .limit(limit);
 
@@ -212,7 +212,7 @@ export class MessageService {
         .where(
           and(
             eq(messages.isPrivate, false),
-            eq(messages.deletedAt as any, null as any)
+            isNull(messages.deletedAt)
           )
         )
         .orderBy(desc(messages.timestamp))


### PR DESCRIPTION
Fix Drizzle ORM queries to correctly handle `deletedAt` null checks, resolving `DrizzleQueryError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bee74c43-f3bb-40da-b5c3-6ebed6a86ce1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bee74c43-f3bb-40da-b5c3-6ebed6a86ce1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

