### PR TITLE
Fix room message fetching error

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -452,8 +452,8 @@ export const storage: LegacyStorage = {
     return await databaseService.getPrivateMessages(userId1, userId2, limit);
   },
 
-  async getRoomMessages(roomId: string, limit = 50) {
-    return await databaseService.getMessages(roomId, limit);
+  async getRoomMessages(roomId: string, limit = 50, offset = 0) {
+    return await databaseService.getMessages(roomId, limit, offset);
   },
 
   // Friends
@@ -512,6 +512,29 @@ export const storage: LegacyStorage = {
   // ========= Room helpers exposed on storage =========
   async getRooms() {
     return await databaseService.getRooms();
+  },
+
+  // ========= Room messages stats/search exposed on storage =========
+  async getRoomMessageCount(roomId: string) {
+    return await databaseService.getRoomMessageCount(roomId);
+  },
+  async getRoomMessageCountSince(roomId: string, since: Date) {
+    return await databaseService.getRoomMessageCountSince(roomId, since);
+  },
+  async getRoomActiveUserCount(roomId: string, since: Date) {
+    return await databaseService.getRoomActiveUserCount(roomId, since);
+  },
+  async getLastRoomMessage(roomId: string) {
+    return await databaseService.getLastRoomMessage(roomId);
+  },
+  async searchRoomMessages(roomId: string, searchQuery: string, limit?: number, offset?: number) {
+    return await databaseService.searchRoomMessages(roomId, searchQuery, limit ?? 20, offset ?? 0);
+  },
+  async countSearchRoomMessages(roomId: string, searchQuery: string) {
+    return await databaseService.countSearchRoomMessages(roomId, searchQuery);
+  },
+  async deleteOldRoomMessages(roomId: string, cutoffDate: Date) {
+    return await databaseService.deleteOldRoomMessages(roomId, cutoffDate);
   },
 
   // Alias to match routes usage


### PR DESCRIPTION
Add missing message count and search functions to `storage` and `databaseService` to resolve `TypeError`.

The `RoomMessageService` was attempting to call `storage.getRoomMessageCount`, but this function (and other related message statistics/search functions) was not defined on the `storage` object. This PR implements these missing functions in `databaseService` and exposes them via the `storage` interface, also adding `offset` support to `getRoomMessages`.

---
<a href="https://cursor.com/background-agent?bcId=bc-72e7ffcb-9458-4c2b-9c61-ec1756b5d1a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72e7ffcb-9458-4c2b-9c61-ec1756b5d1a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

