### PR TITLE
Fix website room navigation error

### DIFF
--- a/client/src/lib/chatOptimization.ts
+++ b/client/src/lib/chatOptimization.ts
@@ -175,10 +175,11 @@ export function useOptimizedMessages(messages: ChatMessage[], containerRef: Reac
     const timeThreshold = 5 * 60 * 1000; // 5 دقائق
     
     messages.forEach(message => {
-      const isSameSender = currentGroup?.sender.id === message.senderId;
-      const isWithinTimeThreshold = currentGroup && 
+      const isSameSender =
+        currentGroup && message.senderId === (currentGroup.sender?.id || currentGroup.messages[0]?.senderId);
+      const isWithinTimeThreshold =
         message.timestamp && currentGroup.timestamp &&
-        (new Date(message.timestamp).getTime() - currentGroup.timestamp.getTime()) < timeThreshold;
+        (new Date(message.timestamp as any).getTime() - currentGroup.timestamp.getTime()) < timeThreshold;
       
       if (isSameSender && isWithinTimeThreshold) {
         currentGroup!.messages.push(message);
@@ -211,7 +212,7 @@ export function useOptimizedMessages(messages: ChatMessage[], containerRef: Reac
             levelProgress: 0
           },
           messages: [message],
-          timestamp: message.timestamp || new Date()
+          timestamp: (message.timestamp instanceof Date) ? message.timestamp : new Date(message.timestamp as any)
         };
         groups.push(currentGroup);
       }

--- a/client/src/types/chat.ts
+++ b/client/src/types/chat.ts
@@ -65,7 +65,7 @@ export interface ChatMessage {
   roomId?: string;
   isPrivate: boolean;
   senderId: number;
-  timestamp: Date;
+  timestamp: Date | string | number;
   messageType: 'text' | 'image' | 'system';
   receiverId?: number;
   sender?: ChatUser;

--- a/client/src/utils/timeUtils.ts
+++ b/client/src/utils/timeUtils.ts
@@ -16,9 +16,11 @@ export function formatTimeAgo(input: string | Date): string {
   return `قبل ${days} يوم`;
 }
 
-export function formatTime(date?: Date): string {
-  if (!date) return '';
-  return date.toLocaleTimeString('ar-SA', {
+export function formatTime(date?: Date | string | number): string {
+  if (date == null) return '';
+  const d = date instanceof Date ? date : new Date(date);
+  if (isNaN(d.getTime())) return '';
+  return d.toLocaleTimeString('ar-SA', {
     hour: '2-digit',
     minute: '2-digit'
   });


### PR DESCRIPTION
Fixes `toLocaleTimeString` error by safely handling various timestamp formats to prevent UI crashes when navigating rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-5070604b-22df-4b4a-951f-86854a6d3418">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5070604b-22df-4b4a-951f-86854a6d3418">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

