### PR TITLE
Fix general room message fetching errors

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -66,10 +66,9 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
       }
     } catch (error) {
       console.error('❌ خطأ في جلب الغرف:', error);
-      // استخدام غرف افتراضية في حالة الخطأ
+      // استخدام غرف افتراضية في حالة الخطأ (بدون غرفة بث افتراضية لمنع طلبات 502)
       setRooms([
         { id: 'general', name: 'الدردشة العامة', description: 'الغرفة الرئيسية للدردشة', isDefault: true, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 0, icon: '', isBroadcast: false, hostId: null, speakers: [], micQueue: [] },
-        { id: 'broadcast', name: 'غرفة البث المباشر', description: 'غرفة خاصة للبث المباشر مع نظام المايك', isDefault: false, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 0, icon: '', isBroadcast: true, hostId: 1, speakers: [], micQueue: [] },
         { id: 'music', name: 'أغاني وسهر', description: 'غرفة للموسيقى والترفيه', isDefault: false, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 0, icon: '', isBroadcast: false, hostId: null, speakers: [], micQueue: [] }
       ]);
     } finally {

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -220,6 +220,9 @@ export function useChat() {
   // إضافة متغير للوصول إلى import.meta.env
   const isDevelopment = process.env.NODE_ENV === 'development';
   
+  // تتبع آخر غرفة طُلب الانضمام لها لمنع تبديل غير مقصود
+  const lastRequestedRoomId = useRef<string>('general');
+  
   // 🚀 تحسين: فلترة محسنة للمستخدمين المعروضين
   const memoizedOnlineUsers = useMemo(() => {
     return state.onlineUsers.filter(user => {
@@ -549,16 +552,18 @@ export function useChat() {
             
           case 'roomJoined':
             if (message.roomId) {
-              // تأكيد تغيير الغرفة من السيرفر
-              dispatch({ type: 'SET_ROOM', payload: message.roomId });
-              
+              // تجاهل أي تأكيد ليس للغرفة المطلوبة أو الحالية لتفادي القفز بين الغرف
+              const target = String(message.roomId);
+              const accept = target === lastRequestedRoomId.current || target === state.currentRoomId;
+              if (!accept) break;
+              dispatch({ type: 'SET_ROOM', payload: target });
               // تحميل رسائل الغرفة الجديدة بقوة لضمان الحصول على أحدث الرسائل
-              loadRoomMessages(message.roomId, true);
+              loadRoomMessages(target, true);
               
               // تحديث الرسائل العامة لتعكس الغرفة الجديدة
               dispatch({ 
                 type: 'SET_PUBLIC_MESSAGES', 
-                payload: state.roomMessages[message.roomId] || [] 
+                payload: state.roomMessages[target] || [] 
               });
               
               }
@@ -780,6 +785,7 @@ export function useChat() {
   const joinRoom = useCallback((roomId: string) => {
     // تغيير الغرفة الحالية فوراً للاستجابة السريعة
     dispatch({ type: 'SET_ROOM', payload: roomId });
+    lastRequestedRoomId.current = roomId;
     
     // تحميل رسائل الغرفة المحفوظة محلياً أولاً
     const existingMessages = state.roomMessages[roomId] || [];

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -15,6 +15,7 @@ export default function ChatPage() {
   // الغرف المتاحة
   const rooms: ChatRoom[] = [
     { id: 'general', name: 'الدردشة العامة', description: 'الغرفة الرئيسية للدردشة', isDefault: true, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 12, icon: '' },
+    { id: 'welcome', name: 'غرفة الترحيب', description: 'غرفة الترحيب بالأعضاء الجدد', isDefault: true, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 3, icon: '' },
     { id: 'music', name: 'أغاني وسهر', description: 'غرفة للموسيقى والترفيه', isDefault: false, createdBy: 1, createdAt: new Date(), isActive: true, userCount: 8, icon: '' }
   ];
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1168,30 +1168,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  // جلب رسائل الغرف
-  app.get("/api/messages/room/:roomId", async (req, res) => {
-    try {
-      const { roomId } = req.params;
-      const limit = parseInt(req.query.limit as string) || 50;
-      
-      // جلب رسائل الغرفة
-      const messages = await storage.getRoomMessages(roomId, limit);
-      
-      // إضافة بيانات المرسلين
-      const messagesWithUsers = await Promise.all(
-        messages.map(async (msg) => {
-          const sender = msg.senderId ? await storage.getUser(msg.senderId) : null;
-          return { ...msg, sender };
-        })
-      );
-
-      res.json({ messages: messagesWithUsers });
-    } catch (error) {
-      console.error('خطأ في جلب رسائل الغرفة:', error);
-      res.status(500).json({ error: "خطأ في الخادم" });
-    }
-  });
-
+  // تم نقل مسارات رسائل الغرف إلى router المنفصل في server/routes/messages.ts لتفادي التكرار
   app.get("/api/messages/private/:userId1/:userId2", async (req, res) => {
     try {
       const userId1 = parseInt(req.params.userId1);


### PR DESCRIPTION
Resolves 502 errors, prevents unintended room switching in UI, and refactors server message routes for better stability and organization.

The 502 errors for broadcast endpoints were caused by a client-side fallback that attempted to fetch data for a non-existent 'broadcast' room. Room switching (e.g., 'General' to 'Welcome' then back) occurred due to delayed `roomJoined` socket events overriding the user's intended room. Server message routes were duplicated, leading to potential conflicts and poor code structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-f66e3d24-e130-48a4-ac22-2a1fa8132ff6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f66e3d24-e130-48a4-ac22-2a1fa8132ff6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

