### PR TITLE
Fix mouse scroll wheel in menus

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -188,9 +188,7 @@ export default function FriendsTabPanel({
     friend.username.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
-  useGrabScroll(friendsScrollRef);
-
-
+  
   return (
     <div className="h-full flex flex-col bg-background/95 backdrop-blur-sm">
       {/* Header */}

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -717,27 +717,31 @@ export default function UnifiedSidebar({
 
       {/* Rooms View */}
       {activeView === 'rooms' && (
-        <RoomComponent
-          currentUser={currentUser}
-          rooms={rooms}
-          currentRoomId={currentRoomId}
-          onRoomChange={onRoomChange}
-          onAddRoom={onAddRoom}
-          onDeleteRoom={onDeleteRoom}
-          onRefreshRooms={onRefreshRooms}
-          viewMode="list"
-          showSearch={true}
-          compact={true}
-        />
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          <RoomComponent
+            currentUser={currentUser}
+            rooms={rooms}
+            currentRoomId={currentRoomId}
+            onRoomChange={onRoomChange}
+            onAddRoom={onAddRoom}
+            onDeleteRoom={onDeleteRoom}
+            onRefreshRooms={onRefreshRooms}
+            viewMode="list"
+            showSearch={true}
+            compact={true}
+          />
+        </div>
       )}
 
       {/* Friends View */}
       {activeView === 'friends' && (
-        <FriendsTabPanel
-          currentUser={currentUser}
-          onlineUsers={users}
-          onStartPrivateChat={onStartPrivateChat || (() => {})}
-        />
+        <div className="flex-1 min-h-0 flex flex-col overflow-hidden">
+          <FriendsTabPanel
+            currentUser={currentUser}
+            onlineUsers={users}
+            onStartPrivateChat={onStartPrivateChat || (() => {})}
+          />
+        </div>
       )}
     </aside>
   );


### PR DESCRIPTION
Enable mouse scroll wheel functionality in Friends and Rooms lists by fixing flex container height and removing a redundant scroll hook.

The scrollable content areas within the Friends and Rooms tabs were not properly constrained by their parent flex containers, causing the mouse wheel events to not trigger scrolling. Wrapping them in `flex-1 min-h-0 overflow-hidden` provides the necessary height constraint for `overflow-y-auto` to function correctly. Additionally, a duplicate `useGrabScroll` call was removed to clean up the code.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e57bf30-a9a3-4043-9df2-95d5ed5a9600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3e57bf30-a9a3-4043-9df2-95d5ed5a9600">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

