### PR TITLE
Investigate website ban button malfunction

### DIFF
--- a/server/middleware/enhancedSecurity.ts
+++ b/server/middleware/enhancedSecurity.ts
@@ -40,6 +40,13 @@ export const requireAuth = async (req: Request, res: Response, next: NextFunctio
     
     if (req.body?.userId) {
       userId = parseInt(req.body.userId);
+    } else if (req.body?.moderatorId) {
+      // السماح باستخدام moderatorId كبديل في مسارات الإدارة
+      userId = parseInt(req.body.moderatorId);
+    } else if (req.query?.userId) {
+      userId = parseInt(req.query.userId as string);
+    } else if (req.query?.moderatorId) {
+      userId = parseInt(req.query.moderatorId as string);
     } else if (req.params?.userId) {
       userId = parseInt(req.params.userId);
     } else if (req.params?.id) {


### PR DESCRIPTION
Fixes non-functional mute, ban, and block buttons by improving authentication and IP/device ID capture.

The moderation buttons were failing because the backend's `requireAuth` middleware expected `userId` while the frontend sent `moderatorId`. This PR updates the middleware to accept `moderatorId` and ensures reliable capture of `clientIP` and `deviceId` from request headers for proper application of bans and blocks. A new endpoint `GET /api/moderation/blocked-devices` is also added for visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-57781542-9ca9-4037-8fd8-bf04306c2b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-57781542-9ca9-4037-8fd8-bf04306c2b4f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

