### PR TITLE
Investigate intermittent permission loss on disconnect/reconnect

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -329,8 +329,8 @@ export default function MessageArea({
                     )}
 
                     {currentUser && message.sender && (() => {
-                      const isOwner = currentUser.role === 'owner';
-                      const isAdmin = currentUser.role === 'admin';
+                      const isOwner = currentUser.userType === 'owner';
+                      const isAdmin = currentUser.userType === 'admin';
                       const isSender = currentUser.id === message.sender.id;
                       const canDelete = isSender || isOwner || isAdmin;
                       if (!canDelete) return null;

--- a/client/src/components/chat/UserContextMenu.tsx
+++ b/client/src/components/chat/UserContextMenu.tsx
@@ -298,7 +298,7 @@ export default function UserContextMenu({
           </ContextMenuItem>
 
           {/* حذف الرسالة */}
-          {messageId && (
+          {messageId && currentUser && (currentUser.id === targetUser.id || ['admin','owner'].includes(currentUser.userType)) && (
             <>
               <div className="my-4 border-t-2 border-gray-300"></div>
               <ContextMenuItem 


### PR DESCRIPTION
Aligns frontend message deletion permission checks with backend `userType` logic to prevent incorrect display of delete options.

The UI previously checked `currentUser.role` for message deletion permissions, while the backend enforces permissions based on `user.userType`. This discrepancy led to the delete message option appearing incorrectly for users, particularly after repeated disconnections and reconnections, as the UI's `role` state could become out of sync with actual `userType` permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-f1ce424b-a61d-405b-86d4-4d58bfcefab5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f1ce424b-a61d-405b-86d4-4d58bfcefab5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

