### PR TITLE
Fix chat room notifications and message speed

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -304,10 +304,9 @@ export const useChat = () => {
                 payload: { roomId, message: chatMessage }
               });
               
-              // تشغيل الإشعار للرسائل الجديدة في الغرفة الحالية
+              // تشغيل صوت خفيف فقط عند الرسائل العامة في الغرفة الحالية
               if (chatMessage.senderId !== state.currentUser?.id && roomId === state.currentRoomId) {
                 playNotificationSound();
-                dispatch({ type: 'SET_NEW_MESSAGE_SENDER', payload: message.sender });
               }
             }
             break;
@@ -450,6 +449,7 @@ export const useChat = () => {
 
     socketInstance.on('privateMessage', handlePrivateMessage);
     // ملاحظة: نتعامل مع الرسائل الخاصة فقط عبر حدث 'privateMessage' المخصص لتجنّب التكرار
+    // منع أي إشعار يشبه الخاص من مسار الرسائل العامة
 
       // معالج حدث الطرد
       socketInstance.on('kicked', (data: any) => {

--- a/server/routes/messages.ts
+++ b/server/routes/messages.ts
@@ -128,7 +128,7 @@ router.post('/room/:roomId', async (req, res) => {
     const io = req.app.get('io');
     if (io) {
       const socketData = {
-        type: 'roomMessage',
+        type: 'newMessage',
         roomId,
         message,
         timestamp: new Date().toISOString()


### PR DESCRIPTION
Removes incorrect private message notifications for room messages and speeds up room message delivery.

The client was displaying a private-like visual alert for all new room messages due to an incorrect state update. Additionally, server-side room message broadcasts were delayed until after point and achievement calculations, causing perceived latency. This PR addresses these by removing the erroneous client-side notification trigger, broadcasting messages immediately after creation on the server, and unifying the REST event type for room messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-4094e71f-997d-49b0-9c95-49fcc12ce4e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4094e71f-997d-49b0-9c95-49fcc12ce4e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

