### PR TITLE
Retrieve all admin and owner users

### DIFF
--- a/client/src/components/chat/OwnerAdminPanel.tsx
+++ b/client/src/components/chat/OwnerAdminPanel.tsx
@@ -102,24 +102,22 @@ export default function OwnerAdminPanel({
   const fetchStaffMembers = async () => {
     setLoading(true);
     try {
-      // جلب جميع المستخدمين وتصفية الإداريين
-      const allUsers = onlineUsers.concat(
-        // يمكن إضافة مستخدمين آخرين من قاعدة البيانات
-      );
-      
-      const staff = allUsers.filter(user => 
-        user.userType === 'moderator' || 
-        user.userType === 'admin' || 
-        user.userType === 'owner'
-      ).map(user => ({
-        id: user.id,
-        username: user.username,
-        userType: user.userType as 'moderator' | 'admin' | 'owner',
-        profileImage: user.profileImage,
-        joinDate: user.joinDate,
-        lastSeen: user.lastSeen,
-        isOnline: true
-      }));
+      // جلب جميع المستخدمين من الخادم ثم تصفية أعضاء الإدارة فقط
+      const response = await apiRequest('/api/users', { method: 'GET' });
+      const allUsers = (response?.users || []) as Array<any>;
+
+      const staff = allUsers
+        .filter((user) => ['moderator', 'admin', 'owner'].includes(user.userType))
+        .map((user) => ({
+          id: user.id,
+          username: user.username,
+          userType: user.userType as 'moderator' | 'admin' | 'owner',
+          profileImage: user.profileImage,
+          joinDate: (user.joinDate ?? user.createdAt) as Date | undefined,
+          lastSeen: (user.lastSeen ?? user.lastActive ?? user.createdAt) as Date | string | undefined,
+          isOnline: Boolean(user.isOnline),
+        }));
+
       setStaffMembers(staff);
     } catch (error) {
       console.error('Error fetching staff:', error);


### PR DESCRIPTION
Update owner admin panel to list all staff (moderator, admin, owner) from the database.

Previously, the panel only displayed online staff members. This change ensures that all staff members, regardless of their online status, are fetched from the database and displayed, fulfilling the requirement to show a comprehensive list.

---
<a href="https://cursor.com/background-agent?bcId=bc-c147afad-d352-4f00-ad91-f8fbc3e99319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c147afad-d352-4f00-ad91-f8fbc3e99319">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

