### PR TITLE
Build project with vite and fix import error

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -385,6 +385,34 @@ class SocketManager {
   getLastRoomId(): string | null {
     return this.lastRoomId || localStorage.getItem('last_room_id');
   }
+
+  saveSession(payload: SaveSessionPayload): void {
+    try {
+      if (payload.token) {
+        localStorage.setItem('auth_token', payload.token);
+      }
+
+      const resolvedRoomId = payload.lastRoomId ?? payload.roomId;
+      if (resolvedRoomId) {
+        this.lastRoomId = resolvedRoomId;
+        localStorage.setItem('last_room_id', resolvedRoomId);
+      }
+
+      if (
+        typeof payload.userId === 'number' &&
+        typeof payload.username === 'string' &&
+        typeof payload.userType === 'string'
+      ) {
+        this.currentUser = {
+          id: payload.userId,
+          username: payload.username,
+          role: payload.userType
+        };
+      }
+    } catch {
+      // ignore storage errors
+    }
+  }
 }
 
 // تصدير instance واحد
@@ -398,6 +426,9 @@ export const getSocket = () =>
   socketManager.getSocket();
 
 export const emitEvent = (event: string, data?: any) => 
+  socketManager.emit(event, data);
+
+export const sendMessage = (event: string, data?: any) =>
   socketManager.emit(event, data);
 
 export const onEvent = (event: string, handler: (...args: any[]) => void) => 
@@ -426,6 +457,18 @@ export const getCurrentUser = () =>
 
 export const getLastRoomId = () => 
   socketManager.getLastRoomId();
+
+export type SaveSessionPayload = {
+  roomId?: string;
+  lastRoomId?: string;
+  userId?: number;
+  username?: string;
+  userType?: string;
+  token?: string;
+};
+
+export const saveSession = (payload: SaveSessionPayload) =>
+  socketManager.saveSession(payload);
 
 // تصدير الـ manager نفسه للاستخدامات المتقدمة
 export default socketManager;

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -9,7 +9,7 @@ import { nanoid } from "nanoid";
 const viteLogger = createLogger();
 
 // استخدام نظام التسجيل الموحد من logger.ts
-import { log as logger } from './utils/logger';
+import logger from './utils/logger';
 
 export function log(message: string, source = "express") {
   logger.info(`[${source}] ${message}`);


### PR DESCRIPTION
Add missing `saveSession` and `sendMessage` exports and fix logger import to resolve build failures.

The `saveSession` function was imported but not exported from `client/src/lib/socket.ts`, causing a Vite build error. Additionally, the server build failed due to an incorrect named import for the logger in `server/vite.ts`. These changes address both issues, allowing the project to build successfully.

---
<a href="https://cursor.com/background-agent?bcId=bc-b989ed5e-d286-44d3-a1eb-e4e490281bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b989ed5e-d286-44d3-a1eb-e4e490281bbd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

