### PR TITLE
Fix joining sequence for website and rooms

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -235,11 +235,7 @@ class SocketManager {
       this.isAuthenticated = true;
       this.currentUser = data.user;
       
-      // إعادة الانضمام للغرفة السابقة إذا كانت موجودة
-      if (this.lastRoomId) {
-        this.joinRoom(this.lastRoomId);
-      }
-      
+      // لا نقوم بالانضمام من العميل بعد المصادقة لتجنب الازدواج؛ الخادم سيتكفل بذلك
       // معالجة الرسائل المعلقة
       this.processQueuedMessages();
       

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -16,8 +16,7 @@ export default function ChatPage() {
   const handleUserLogin = (user: ChatUser) => {
     chat.connect(user);
     setShowWelcome(false);
-    // الانضمام تلقائياً للغرفة العامة، باقي التنقل من داخل الواجهة
-    chat.joinRoom('general');
+    // الانضمام التلقائي للغرفة العامة يتم الآن من الخادم بعد المصادقة
   };
 
   // لم يعد هناك محدد غرف على مستوى الصفحة


### PR DESCRIPTION
Remove client-side automatic room joining to prevent double joins and ensure server-side consistency.

The previous client-side logic for automatically joining the 'general' room after login and re-joining the last room on `authSuccess` could lead to redundant or premature join events, as the server also handles initial room assignment. This change centralizes the initial room joining responsibility to the server.

---
<a href="https://cursor.com/background-agent?bcId=bc-3a722de8-1e83-4bf6-92b8-5a1e6028885f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3a722de8-1e83-4bf6-92b8-5a1e6028885f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

