### PR TITLE
Fix broadcast info api errors

### DIFF
--- a/server/routes/rooms.ts
+++ b/server/routes/rooms.ts
@@ -271,21 +271,22 @@ router.get('/:roomId/users', async (req, res) => {
  * GET /api/rooms/:roomId/broadcast-info
  * جلب معلومات البث للغرفة
  */
-router.get('/:roomId/broadcast-info', async (req, res) => {
-  try {
-    const { roomId } = req.params;
-    const info = await roomService.getBroadcastInfo(roomId);
-    
-    if (!info) {
-      return res.status(404).json({ error: 'الغرفة ليست غرفة بث' });
+  router.get('/:roomId/broadcast-info', async (req, res) => {
+    try {
+      const { roomId } = req.params;
+      const info = await roomService.getBroadcastInfo(roomId);
+      
+      // بدلاً من إرجاع 404، نرجع 200 مع info=null لتجنّب ضوضاء الأخطاء في الواجهة
+      if (!info) {
+        return res.json({ info: null, message: 'الغرفة ليست غرفة بث' });
+      }
+      
+      res.json({ info });
+    } catch (error) {
+      console.error('خطأ في جلب معلومات البث:', error);
+      res.status(500).json({ error: 'خطأ في الخادم' });
     }
-    
-    res.json({ info });
-  } catch (error) {
-    console.error('خطأ في جلب معلومات البث:', error);
-    res.status(500).json({ error: 'خطأ في الخادم' });
-  }
-});
+  });
 
 /**
  * POST /api/rooms/:roomId/request-mic


### PR DESCRIPTION
Change `/api/rooms/:roomId/broadcast-info` to return 200 with `info: null` for non-broadcast rooms to prevent client-side 404 errors.

---
<a href="https://cursor.com/background-agent?bcId=bc-c17efef2-e6ac-4cc8-b09d-3564beccb1ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c17efef2-e6ac-4cc8-b09d-3564beccb1ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

