### PR TITLE
Move items to the right side

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -450,8 +450,8 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         })()}
       </main>
 
-      {/* Footer - مع التبويبات الأربعة المنقولة */}
-      <footer className="bg-secondary py-4 px-6 flex justify-end items-center shadow-2xl border-t border-accent">
+      {/* Footer - مع التبويبات الأربعة المنقولة إلى الجهة اليمنى */}
+      <footer className="bg-secondary py-4 px-6 flex justify-start items-center shadow-2xl border-t border-accent">
         <div className="flex gap-3">
           {/* الحوائط */}
           <Button 


### PR DESCRIPTION
Move the four footer tabs to the right side of the interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-5dee1b46-36b9-46ab-a4af-48419ce4b173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5dee1b46-36b9-46ab-a4af-48419ce4b173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

