### PR TITLE
Fix message tab error on person click

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -181,12 +181,13 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
   };
 
   const handlePrivateMessage = (user: ChatUser) => {
-    setSelectedPrivateUser(user);
-    // تحميل سجل الرسائل الخاصة عند فتح الصندوق
-    try {
-      chat.loadPrivateConversation(user.id);
-    } catch {}
-    closeUserPopup();
+    setShowMessages(false);
+    setTimeout(() => {
+      setSelectedPrivateUser(user);
+      try {
+        chat.loadPrivateConversation(user.id);
+      } catch {}
+    }, 0);
   };
 
   const closePrivateMessage = () => {
@@ -585,7 +586,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           user={userPopup.user}
           x={userPopup.x}
           y={userPopup.y}
-          onPrivateMessage={() => handlePrivateMessage(userPopup.user!)}
+          onPrivateMessage={() => { closeUserPopup(); setTimeout(() => handlePrivateMessage(userPopup.user!), 0); }}
           onAddFriend={() => handleAddFriend(userPopup.user!)}
           onIgnore={() => {
             // إزالة زر التجاهل من UserPopup - الآن في الملف الشخصي فقط
@@ -662,8 +663,8 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           privateConversations={chat.privateConversations}
           onlineUsers={chat.onlineUsers}
           onStartPrivateChat={(user) => {
-            setSelectedPrivateUser(user);
             setShowMessages(false);
+            setTimeout(() => setSelectedPrivateUser(user), 0);
           }}
         />
       )}

--- a/client/src/components/chat/MessagesPanel.tsx
+++ b/client/src/components/chat/MessagesPanel.tsx
@@ -100,7 +100,7 @@ export default function MessagesPanel({
                     <button
                       key={user.id}
                       className="w-full text-right cursor-pointer hover:bg-accent/20 transition-all duration-200 p-2 rounded-lg"
-                      onClick={() => { onStartPrivateChat(user); onClose(); }}
+                      onClick={() => { onClose(); setTimeout(() => onStartPrivateChat(user), 0); }}
                     >
                       <div className="flex items-center gap-3">
                         <img
@@ -143,7 +143,7 @@ export default function MessagesPanel({
                     <button
                       key={user.id}
                       className="w-full text-right cursor-pointer hover:bg-accent/20 transition-all duration-200 p-2 rounded-lg"
-                      onClick={() => { onStartPrivateChat(user); onClose(); }}
+                      onClick={() => { onClose(); setTimeout(() => onStartPrivateChat(user), 0); }}
                     >
                       <div className="flex items-center gap-3">
                         <img


### PR DESCRIPTION
Resolves UI flicker and navigation issues when opening private chats by ensuring proper sequencing of UI component closures and openings.

The previous implementation attempted to close a panel/popup and open a private chat simultaneously, leading to a visual flicker or navigation failure. Introducing a micro-delay (`setTimeout(0)`) ensures the current UI element fully closes before the private chat is initiated, providing a smoother user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-418a1d94-d54e-45a0-86f7-04e7fde7a78f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-418a1d94-d54e-45a0-86f7-04e7fde7a78f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

