### PR TITLE
Fix private chat opening bug

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -251,14 +251,25 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         window.history.replaceState(null, '', window.location.pathname);
       } else if (pmMatch) {
         const userId = parseInt(pmMatch[1]);
-        const user = chat.onlineUsers.find(u => u.id === userId);
-        if (user) {
-          setSelectedPrivateUser(user);
-          try { chat.loadPrivateConversation(user.id); } catch {}
-        } else {
-          showErrorToast("لم نتمكن من العثور على هذا المستخدم", "مستخدم غير موجود");
-        }
-        window.history.replaceState(null, '', window.location.pathname);
+        const openPm = async () => {
+          let user = chat.onlineUsers.find(u => u.id === userId);
+          if (!user) {
+            try {
+              const data = await apiRequest(`/api/users/${userId}?t=${Date.now()}`);
+              if (data && data.id) {
+                user = data as any;
+              }
+            } catch {}
+          }
+          if (user) {
+            setSelectedPrivateUser(user);
+            try { chat.loadPrivateConversation(user.id); } catch {}
+          } else {
+            showErrorToast("لم نتمكن من العثور على هذا المستخدم", "مستخدم غير موجود");
+          }
+          window.history.replaceState(null, '', window.location.pathname);
+        };
+        openPm();
       }
     };
 
@@ -417,7 +428,10 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
               onAddRoom={handleAddRoom}
               onDeleteRoom={handleDeleteRoom}
               onRefreshRooms={handleRefreshRooms}
-              onStartPrivateChat={setSelectedPrivateUser}
+              onStartPrivateChat={(user) => {
+                setSelectedPrivateUser(user);
+                try { chat.loadPrivateConversation(user.id); } catch {}
+              }}
             />
           </div>
         )}

--- a/client/src/components/chat/UserContextMenu.tsx
+++ b/client/src/components/chat/UserContextMenu.tsx
@@ -42,6 +42,7 @@ interface UserContextMenuProps {
   messageId?: number;
   messageContent?: string;
   onAction?: () => void;
+  onStartPrivateChat?: (user: ChatUser) => void;
 }
 
 export default function UserContextMenu({
@@ -50,7 +51,8 @@ export default function UserContextMenu({
   currentUser,
   messageId,
   messageContent,
-  onAction
+  onAction,
+  onStartPrivateChat
 }: UserContextMenuProps) {
   const [showMuteDialog, setShowMuteDialog] = useState(false);
   const [showKickDialog, setShowKickDialog] = useState(false);
@@ -316,9 +318,8 @@ export default function UserContextMenu({
           {/* إجراءات عامة */}
           <ContextMenuItem className="flex items-center gap-3 text-blue-600 font-semibold bg-blue-50 hover:bg-blue-100 border border-blue-200 rounded-lg p-2 cursor-pointer transition-all duration-200"
             onClick={() => {
-              // افتح نافذة الخاص عبر الهاش لالتقاطه من الواجهة الرئيسية
               if (targetUser?.id) {
-                window.location.hash = `#pm${targetUser.id}`;
+                onStartPrivateChat?.(targetUser);
               }
             }}
           >


### PR DESCRIPTION
Refactors private chat initiation to use direct prop passing, improving reliability and fixing intermittent overlay issues, while adding a fallback for hash-based links.

The previous implementation relied on `window.location.hash` and a `hashchange` listener, which was prone to race conditions where the target user might not be immediately available in `chat.onlineUsers`. This often resulted in the private chat window failing to open or a lingering overlay. This change directly triggers the private chat opening for user-initiated actions, bypassing the unreliable hash mechanism, and adds a robust fallback for hash-based navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-85f0659f-ff33-4419-ab9e-efb4761eb9aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-85f0659f-ff33-4419-ab9e-efb4761eb9aa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

