### PR TITLE
Outline white SVGs with black

### DIFF
--- a/client/public/svgs/white.svg
+++ b/client/public/svgs/white.svg
@@ -6,8 +6,8 @@
     </linearGradient>
   </defs>
   <polygon points="10,30 30,10 70,10 90,30 60,90 40,90"
-           fill="url(#whiteGradient)" stroke="#000000" stroke-width="2"/>
-  <line x1="30" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1"/>
-  <line x1="70" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1"/>
-  <line x1="10" y1="30" x2="90" y2="30" stroke="#000000" stroke-width="1"/>
+           fill="url(#whiteGradient)" stroke="#000000" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>
+  <line x1="30" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+  <line x1="70" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+  <line x1="10" y1="30" x2="90" y2="30" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
 </svg>

--- a/svgs/white.svg
+++ b/svgs/white.svg
@@ -6,8 +6,8 @@
     </linearGradient>
   </defs>
   <polygon points="10,30 30,10 70,10 90,30 60,90 40,90"
-           fill="url(#whiteGradient)" stroke="#000000" stroke-width="2"/>
-  <line x1="30" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1"/>
-  <line x1="70" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1"/>
-  <line x1="10" y1="30" x2="90" y2="30" stroke="#000000" stroke-width="1"/>
+           fill="url(#whiteGradient)" stroke="#000000" stroke-width="2" vector-effect="non-scaling-stroke" stroke-linejoin="round"/>
+  <line x1="30" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+  <line x1="70" y1="10" x2="50" y2="90" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
+  <line x1="10" y1="30" x2="90" y2="30" stroke="#000000" stroke-width="1.25" vector-effect="non-scaling-stroke" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
Add black outlines to white SVG icons to improve visibility and ensure consistent stroke width on scaling.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e03bd1f-0c78-4066-b28a-db80453a4fcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8e03bd1f-0c78-4066-b28a-db80453a4fcc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

