### PR TITLE
Fix scroll button and remove black background

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -28,7 +28,8 @@ export default function FriendsTabPanel({
   onStartPrivateChat
 }: FriendsTabPanelProps) {
   const friendsScrollRef = useRef<HTMLDivElement>(null);
-  useGrabScroll(friendsScrollRef);
+  // Temporarily disabled to fix scrolling issues
+  // useGrabScroll(friendsScrollRef);
   const [friends, setFriends] = useState<Friend[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTab, setActiveTab] = useState<'friends' | 'requests'>('friends');
@@ -247,7 +248,7 @@ export default function FriendsTabPanel({
       </div>
 
       {/* Content */}
-      <div ref={friendsScrollRef} className="relative flex-1 overflow-y-auto p-4 cursor-grab">
+      <div ref={friendsScrollRef} className="flex-1 overflow-y-auto p-4">
         {/* Friends Tab */}
         {activeTab === 'friends' && (
           <div className="space-y-3">

--- a/client/src/components/chat/RoomComponent.tsx
+++ b/client/src/components/chat/RoomComponent.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ChatRoom, ChatUser } from '@/types/chat';
 import { dedupeRooms } from '@/utils/roomUtils';
-import { useGrabScroll } from '@/hooks/useGrabScroll';
+// import { useGrabScroll } from '@/hooks/useGrabScroll';
 
 
 interface RoomComponentProps {
@@ -278,7 +278,7 @@ export default function RoomComponent({
 }: RoomComponentProps) {
   // الحالات المحلية
   const listScrollRef = React.useRef<HTMLDivElement>(null);
-  useGrabScroll(listScrollRef);
+  // useGrabScroll(listScrollRef);
   const [showAddRoom, setShowAddRoom] = useState(false);
   const [newRoomName, setNewRoomName] = useState('');
   const [newRoomDescription, setNewRoomDescription] = useState('');
@@ -479,7 +479,7 @@ export default function RoomComponent({
       </div>
 
       {/* المحتوى */}
-      <div ref={listScrollRef} className="relative flex-1 overflow-y-auto p-4 cursor-grab">
+      <div ref={listScrollRef} className="flex-1 overflow-y-auto p-4">
         {/* زر إضافة غرفة */}
         {canCreateRooms && (
           <Button

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -175,8 +175,9 @@ export default function UnifiedSidebar({
   const usersScrollRef = useRef<HTMLDivElement>(null);
   const wallsScrollRef = useRef<HTMLDivElement>(null);
 
-  useGrabScroll(usersScrollRef);
-  useGrabScroll(wallsScrollRef);
+  // Temporarily disabled to fix scrolling issues
+  // useGrabScroll(usersScrollRef);
+  // useGrabScroll(wallsScrollRef);
 
   const { data: wallData, isFetching } = useQuery<{ success?: boolean; posts: WallPost[] }>({
     queryKey: ['/api/wall/posts', activeTab, currentUser?.id],
@@ -466,7 +467,7 @@ export default function UnifiedSidebar({
 
       {/* Users View */}
       {activeView === 'users' && (
-                  <div ref={usersScrollRef} className="relative flex-1 overflow-y-auto p-4 space-y-3 cursor-grab bg-white">
+        <div ref={usersScrollRef} className="flex-1 overflow-y-auto p-4 space-y-3 bg-white">
           <div className="relative">
             <span className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400">🔍</span>
             <Input
@@ -580,7 +581,7 @@ export default function UnifiedSidebar({
               </TabsTrigger>
             </TabsList>
 
-            <div ref={wallsScrollRef} className="relative flex-1 overflow-y-auto px-2 cursor-grab">
+            <div ref={wallsScrollRef} className="flex-1 overflow-y-auto px-2">
               {/* Post Creation */}
               {currentUser && currentUser.userType !== 'guest' && (
                 <Card className="mb-4 border border-gray-200">

--- a/client/src/components/chat/WallPanel.tsx
+++ b/client/src/components/chat/WallPanel.tsx
@@ -33,7 +33,8 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
   const queryClient = useQueryClient();
   const panelScrollRef = useRef<HTMLDivElement>(null);
 
-  useGrabScroll(panelScrollRef);
+  // Temporarily disabled to fix scrolling issues
+  // useGrabScroll(panelScrollRef);
 
   // جلب المنشورات عبر React Query مع كاش قوي
   const { data: wallData, isFetching } = useQuery<{ success?: boolean; posts: WallPost[] }>({
@@ -441,7 +442,7 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
               )}
 
               <TabsContent value={activeTab} className="flex-1">
-                <div ref={panelScrollRef} className="relative overflow-y-auto space-y-4 pr-2 cursor-grab">
+                <div ref={panelScrollRef} className="overflow-y-auto space-y-4 pr-2">
                   <WallPostList
                     posts={posts}
                     loading={loading}

--- a/تقرير-إصلاح-مشاكل-التمرير-2025.md
+++ b/تقرير-إصلاح-مشاكل-التمرير-2025.md
@@ -1,0 +1,89 @@
+# تقرير إصلاح مشاكل التمرير في القوائم
+
+## التاريخ: يناير 2025
+
+## المشكلة
+- عدم القدرة على التمرير في قوائم المستخدمين، الأصدقاء، الحوائط، والغرف
+- وجود خلفية سوداء تمنع رؤية المحتوى أسفل القوائم
+- عدم القدرة على رؤية المستخدمين والأصدقاء في أسفل القوائم
+- عدم القدرة على تصفح المنشورات بشكل صحيح
+
+## الإصلاحات المطبقة
+
+### 1. إزالة أنماط CSS التي تمنع التمرير
+تم إزالة الأنماط التالية من جميع المكونات:
+- `cursor-grab` - كان يتداخل مع التمرير الطبيعي
+- `relative` - تم إزالته من حاويات التمرير لتجنب مشاكل التموضع
+
+### 2. تعطيل hook useGrabScroll
+تم تعطيل استخدام `useGrabScroll` مؤقتاً في المكونات التالية:
+- `UserSidebarWithWalls.tsx`
+- `FriendsTabPanel.tsx`
+- `WallPanel.tsx`
+- `RoomComponent.tsx`
+
+### 3. الملفات المعدلة
+
+#### `/workspace/client/src/components/chat/UserSidebarWithWalls.tsx`
+```diff
+- <div ref={usersScrollRef} className="relative flex-1 overflow-y-auto p-4 space-y-3 cursor-grab bg-white">
++ <div ref={usersScrollRef} className="flex-1 overflow-y-auto p-4 space-y-3 bg-white">
+
+- <div ref={wallsScrollRef} className="relative flex-1 overflow-y-auto px-2 cursor-grab">
++ <div ref={wallsScrollRef} className="flex-1 overflow-y-auto px-2">
+
+- useGrabScroll(usersScrollRef);
+- useGrabScroll(wallsScrollRef);
++ // Temporarily disabled to fix scrolling issues
++ // useGrabScroll(usersScrollRef);
++ // useGrabScroll(wallsScrollRef);
+```
+
+#### `/workspace/client/src/components/chat/FriendsTabPanel.tsx`
+```diff
+- <div ref={friendsScrollRef} className="relative flex-1 overflow-y-auto p-4 cursor-grab">
++ <div ref={friendsScrollRef} className="flex-1 overflow-y-auto p-4">
+
+- useGrabScroll(friendsScrollRef);
++ // Temporarily disabled to fix scrolling issues
++ // useGrabScroll(friendsScrollRef);
+```
+
+#### `/workspace/client/src/components/chat/WallPanel.tsx`
+```diff
+- <div ref={panelScrollRef} className="relative overflow-y-auto space-y-4 pr-2 cursor-grab">
++ <div ref={panelScrollRef} className="overflow-y-auto space-y-4 pr-2">
+
+- useGrabScroll(panelScrollRef);
++ // Temporarily disabled to fix scrolling issues
++ // useGrabScroll(panelScrollRef);
+```
+
+#### `/workspace/client/src/components/chat/RoomComponent.tsx`
+```diff
+- <div ref={listScrollRef} className="relative flex-1 overflow-y-auto p-4 cursor-grab">
++ <div ref={listScrollRef} className="flex-1 overflow-y-auto p-4">
+
+- import { useGrabScroll } from '@/hooks/useGrabScroll';
++ // import { useGrabScroll } from '@/hooks/useGrabScroll';
+
+- useGrabScroll(listScrollRef);
++ // useGrabScroll(listScrollRef);
+```
+
+## النتيجة المتوقعة
+بعد تطبيق هذه الإصلاحات:
+1. ✅ يمكن التمرير بحرية في جميع القوائم باستخدام عجلة الفأرة
+2. ✅ يمكن رؤية جميع المستخدمين والأصدقاء في أسفل القوائم
+3. ✅ يمكن تصفح جميع المنشورات في الحوائط
+4. ✅ لا توجد خلفية سوداء تحجب المحتوى
+
+## ملاحظات
+- تم تعطيل ميزة السحب للتمرير (drag-to-scroll) مؤقتاً لحل مشكلة التمرير الأساسية
+- يمكن إعادة تفعيل `useGrabScroll` لاحقاً بعد تحسينه ليعمل بشكل صحيح مع التمرير العادي
+- جميع القوائم الآن تستخدم التمرير الطبيعي للمتصفح
+
+## التوصيات المستقبلية
+1. تحسين `useGrabScroll` hook ليعمل بالتوازي مع التمرير العادي دون تعارض
+2. إضافة مؤشرات بصرية للتمرير (scroll indicators) لتحسين تجربة المستخدم
+3. اختبار الأداء على الأجهزة المختلفة للتأكد من سلاسة التمرير


### PR DESCRIPTION
Fixes scrolling issues in user, friends, wall, and room lists by disabling the `useGrabScroll` hook and removing conflicting CSS styles.

The `useGrabScroll` hook and `cursor-grab` CSS class were interfering with native browser scrolling, preventing users from seeing content at the bottom of lists and causing a perceived "black background" issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-6fc1f8d3-fe79-4d0d-a0dd-b2d4fc9e1db1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6fc1f8d3-fe79-4d0d-a0dd-b2d4fc9e1db1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

