### PR TITLE
Remove dark overlay and unify list display

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -539,7 +539,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
        </main>
 
       {/* Footer - تبويبات سفلية. على الجوال: تفتح بملء الشاشة، وعلى الشاشات الكبيرة: تظهر كلوحة جانبية قابلة للإخفاء */}
-      <footer className="sticky bottom-0 z-40 bg-secondary py-1.5 px-3 sm:py-2 sm:px-6 flex justify-start items-center shadow-2xl border-t border-accent bottombar-white">
+      <footer className="sticky bottom-0 z-40 bg-secondary py-1.5 px-3 sm:py-2 sm:px-6 flex justify-start items-center border-t border-accent bottombar-white">
         <div className="flex gap-2 sm:gap-3 overflow-x-auto max-w-full">
           {/* الحوائط */}
                      <Button 

--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -12,7 +12,7 @@ import { getImageSrc } from '@/utils/imageUtils';
 import type { ChatUser } from '@/types/chat';
 import type { Friend, FriendRequest } from '@/../../shared/types';
 import { formatTimeAgo, getStatusColor } from '@/utils/timeUtils';
-import { useGrabScroll } from '@/hooks/useGrabScroll';
+import { useScrollArea } from '@/hooks/useScrollArea';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 
 // Using shared types for Friend and FriendRequest
@@ -28,9 +28,7 @@ export default function FriendsTabPanel({
   onlineUsers,
   onStartPrivateChat
 }: FriendsTabPanelProps) {
-  const friendsScrollRef = useRef<HTMLDivElement>(null);
-  // Temporarily disabled to fix scrolling issues
-  // useGrabScroll(friendsScrollRef);
+  const { scrollRef: friendsScrollRef } = useScrollArea();
   const [friends, setFriends] = useState<Friend[]>([]);
   const [searchTerm, setSearchTerm] = useState('');
   const [activeTab, setActiveTab] = useState<'friends' | 'requests'>('friends');

--- a/client/src/components/chat/RoomComponent.tsx
+++ b/client/src/components/chat/RoomComponent.tsx
@@ -8,7 +8,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import type { ChatRoom, ChatUser } from '@/types/chat';
 import { dedupeRooms } from '@/utils/roomUtils';
-// import { useGrabScroll } from '@/hooks/useGrabScroll';
+import { useScrollArea } from '@/hooks/useScrollArea';
 
 
 interface RoomComponentProps {
@@ -277,8 +277,7 @@ export default function RoomComponent({
   allowRefresh = true
 }: RoomComponentProps) {
   // الحالات المحلية
-  const listScrollRef = React.useRef<HTMLDivElement>(null);
-  // useGrabScroll(listScrollRef);
+  const { scrollRef: listScrollRef } = useScrollArea();
   const [showAddRoom, setShowAddRoom] = useState(false);
   const [newRoomName, setNewRoomName] = useState('');
   const [newRoomDescription, setNewRoomDescription] = useState('');

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -20,7 +20,7 @@ import UserRoleBadge from './UserRoleBadge';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Socket } from 'socket.io-client';
 import { getSocket, saveSession } from '@/lib/socket';
-import { useGrabScroll } from '@/hooks/useGrabScroll';
+import { useScrollArea } from '@/hooks/useScrollArea';
 
 
 
@@ -172,12 +172,8 @@ export default function UnifiedSidebar({
 
   // جلب المنشورات عبر React Query مع كاش قوي
   const socketRef = useRef<Socket | null>(null);
-  const usersScrollRef = useRef<HTMLDivElement>(null);
-  const wallsScrollRef = useRef<HTMLDivElement>(null);
-
-  // Temporarily disabled to fix scrolling issues
-  // useGrabScroll(usersScrollRef);
-  // useGrabScroll(wallsScrollRef);
+  const { scrollRef: usersScrollRef } = useScrollArea();
+  const { scrollRef: wallsScrollRef } = useScrollArea();
 
   const { data: wallData, isFetching } = useQuery<{ success?: boolean; posts: WallPost[] }>({
     queryKey: ['/api/wall/posts', activeTab, currentUser?.id],
@@ -412,7 +408,7 @@ export default function UnifiedSidebar({
   // تم نقل دالة formatTimeAgo إلى utils/timeUtils.ts (تستخدم من الاستيراد أعلاه)
 
   return (
-    	<aside className="w-full bg-white text-sm overflow-hidden border-l border-gray-200 shadow-lg flex flex-col min-h-0">
+    	<aside className="w-full bg-white text-sm overflow-hidden border-l border-gray-200 flex flex-col min-h-0">
       {/* Toggle Buttons - always visible now */}
       <div className="flex border-b border-gray-200">
         <Button

--- a/client/src/components/chat/WallPanel.tsx
+++ b/client/src/components/chat/WallPanel.tsx
@@ -12,7 +12,7 @@ import type { WallPost, CreateWallPostData, ChatUser } from '@/types/chat';
 import { Socket } from 'socket.io-client';
 import { getSocket, saveSession } from '@/lib/socket';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { useGrabScroll } from '@/hooks/useGrabScroll';
+import { useScrollArea } from '@/hooks/useScrollArea';
 
 interface WallPanelProps {
   isOpen: boolean;
@@ -31,10 +31,7 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
   const socket = useRef<Socket | null>(null);
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const panelScrollRef = useRef<HTMLDivElement>(null);
-
-  // Temporarily disabled to fix scrolling issues
-  // useGrabScroll(panelScrollRef);
+  const { scrollRef: panelScrollRef } = useScrollArea();
 
   // جلب المنشورات عبر React Query مع كاش قوي
   const { data: wallData, isFetching } = useQuery<{ success?: boolean; posts: WallPost[] }>({
@@ -309,7 +306,7 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
 
   return (
     <div className="fixed inset-0 bg-black/60 backdrop-blur-sm flex items-center justify-center z-50 p-2 sm:p-6" dir="rtl">
-      <div className="bg-background/95 backdrop-blur-xl rounded-2xl shadow-2xl border border-border/50 w-full sm:w-[95vw] h-[92dvh] sm:h-[92vh] flex flex-col overflow-hidden min-h-0 max-w-[1200px]">
+      <div className="bg-background/95 backdrop-blur-xl rounded-2xl border border-border/50 w-full sm:w-[95vw] h-[92dvh] sm:h-[92vh] flex flex-col overflow-hidden min-h-0 max-w-[1200px]">
         {/* رأس النافذة المحسن */}
         <div className="flex items-center justify-between p-6 border-b border-border/50 bg-gradient-to-l from-primary/5 to-transparent">
           <div className="flex items-center gap-3">
@@ -343,7 +340,7 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
 
               {/* نموذج النشر المحسن */}
               {currentUser.userType !== 'guest' && (
-                <Card className="mb-6 border-0 shadow-lg bg-background/80 backdrop-blur-sm">
+                <Card className="mb-6 border-0 bg-background/80 backdrop-blur-sm">
                   <CardContent className="p-6">
                     <div className="flex items-center gap-3 mb-4">
                       <div className="w-10 h-10 rounded-full bg-gradient-to-br from-primary/20 to-primary/10 flex items-center justify-center">

--- a/client/src/hooks/useScrollArea.ts
+++ b/client/src/hooks/useScrollArea.ts
@@ -1,0 +1,46 @@
+import { useRef, useEffect } from 'react';
+
+/**
+ * Hook موحد لإدارة منطقة التمرير
+ * يوفر إمكانيات التمرير المحسنة لجميع القوائم
+ */
+export function useScrollArea() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+
+    // تحسين أداء التمرير
+    scrollElement.style.overscrollBehavior = 'contain';
+    scrollElement.style.touchAction = 'pan-y';
+    
+    return () => {
+      // تنظيف
+    };
+  }, []);
+
+  const scrollToBottom = (behavior: ScrollBehavior = 'smooth') => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({
+        top: scrollRef.current.scrollHeight,
+        behavior
+      });
+    }
+  };
+
+  const scrollToTop = (behavior: ScrollBehavior = 'smooth') => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTo({
+        top: 0,
+        behavior
+      });
+    }
+  };
+
+  return {
+    scrollRef,
+    scrollToBottom,
+    scrollToTop
+  };
+}


### PR DESCRIPTION
Remove dark shadows from list footers and unify scroll behavior across Friends, Rooms, and Walls panels.

This PR addresses the user's request to remove dark shading from the bottom of lists (Friends, Rooms, Walls) and standardize their appearance to a consistent white background. It also centralizes scroll logic by introducing a `useScrollArea` hook, replacing redundant scroll implementations.

---
<a href="https://cursor.com/background-agent?bcId=bc-d52a34f3-de34-40f2-8a49-a3ae60f6916d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d52a34f3-de34-40f2-8a49-a3ae60f6916d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

