### PR TITLE
تحقيق عميق في مشكلة الخلفية السوداء والتمرير

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -465,7 +465,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
       <main className="flex flex-1 overflow-hidden min-h-0 flex-col sm:flex-row">
         {/* الشريط الجانبي - على الجوال يعرض بملء الشاشة عند اختيار التبويب */}
         {activeView !== 'hidden' && (
-          <div className={`${isMobile ? 'w-full' : activeView === 'walls' ? 'w-full sm:w-96' : activeView === 'friends' ? 'w-full sm:w-80' : 'w-full sm:w-64'} max-w-full shrink-0 transition-all duration-300`}>
+          <div className={`${isMobile ? 'w-full flex-1 min-h-0' : activeView === 'walls' ? 'w-full sm:w-96' : activeView === 'friends' ? 'w-full sm:w-80' : 'w-full sm:w-64'} max-w-full sm:shrink-0 transition-all duration-300`}>
             <UnifiedSidebar 
               users={chat.onlineUsers}
               onUserClick={handleUserClick}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Adjust `UnifiedSidebar` container styles on mobile to enable scrolling and remove the black background at the bottom of chat lists.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `UnifiedSidebar` container on mobile was not expanding to fill the available height, which prevented its internal `overflow-y-auto` from functioning and caused the dark page background to appear below the lists. Adding `flex-1 min-h-0` and making `shrink-0` desktop-only resolves this layout issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c9e289a-6e1c-4d34-a7de-839c8a45e94c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c9e289a-6e1c-4d34-a7de-839c8a45e94c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

