### PR TITLE
Fix theme selection in settings

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -825,7 +825,10 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           onClose={() => setShowThemeSelector(false)}
           currentUser={chat.currentUser}
           onThemeUpdate={(theme) => {
-            }}
+            if (chat.updateCurrentUser) {
+              chat.updateCurrentUser({ userTheme: theme });
+            }
+          }}
         />
       )}
 


### PR DESCRIPTION
Fixes theme selection in settings by preventing saving on hover and ensuring immediate UI update upon confirmation.

The previous implementation incorrectly saved the theme to `localStorage` during hover previews, leading to unintended theme changes. This PR ensures themes are only saved when explicitly selected and immediately updates the UI to reflect the chosen theme, resolving the "wrong theme" and "not accepting" issues reported by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd78e59a-db2c-4227-94e7-356a3871776b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bd78e59a-db2c-4227-94e7-356a3871776b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

