### PR TITLE
Refactor user profile color change logic

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1998,12 +1998,16 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
               <div className="additional-details">
                 <p>💬 عدد الرسائل: <span>0</span></p>
                 <p>⭐ مستوى العضو: <span>مستوى {localUser?.level || 1}</span></p>
-                <p onClick={() => setCurrentEditType('theme')} style={{ cursor: 'pointer' }}>
-                  🎨 لون الملف الشخصي: <span>اضغط للتغيير</span>
-                </p>
-                <p onClick={() => setCurrentEditType('effects')} style={{ cursor: 'pointer' }}>
-                  ✨ تأثيرات حركية: <span>اضغط للتغيير</span>
-                </p>
+                {['moderator','admin','owner'].includes(String(currentUser?.userType || '').toLowerCase()) && (
+                  <>
+                    <p onClick={() => setCurrentEditType('theme')} style={{ cursor: 'pointer' }}>
+                      🎨 لون الملف الشخصي: <span>اضغط للتغيير</span>
+                    </p>
+                    <p onClick={() => setCurrentEditType('effects')} style={{ cursor: 'pointer' }}>
+                      ✨ تأثيرات حركية: <span>اضغط للتغيير</span>
+                    </p>
+                  </>
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
Streamline user list item styling by separating logic for regular and privileged users.

Previously, the user box styling in the list could be influenced by both username color (from settings) and profile background/theme/effects (from profile). This led to conflicting and redundant styling rules. This PR resolves the conflict by ensuring regular users' boxes are styled solely by their username color, while privileged users retain control over their box styling via profile themes and effects, with `profileBackgroundColor` influence removed entirely.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5112841-47fb-4900-bdd1-9126417c1a36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5112841-47fb-4900-bdd1-9126417c1a36">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

