### PR TITLE
Add userTheme to data normalization

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1570,7 +1570,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
             ...user,
             profileEffect: (user as any)?.profileEffect || 'none',
             profileBackgroundColor: (user as any)?.profileBackgroundColor || '#3c0d0d',
-            usernameColor: (user as any)?.usernameColor || '#FFFFFF'
+            usernameColor: (user as any)?.usernameColor || '#FFFFFF',
+            userTheme: (user as any)?.userTheme || 'default'
           };
         } catch {}
         


### PR DESCRIPTION
Add `userTheme` to user data normalization to ensure a default value is always present.

The `userTheme` property was not being initialized with a default value during user data normalization, unlike other profile-related properties, which could lead to `undefined` values and subsequent issues when accessing the theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-e4b33d9f-e5a3-4f4e-9a40-3b06c3945796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e4b33d9f-e5a3-4f4e-9a40-3b06c3945796">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

