### PR TITLE
Check username color against profile colors

### DIFF
--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -10,6 +10,7 @@ import {
   Palette,
   Brush
 } from 'lucide-react';
+import { getFinalUsernameColor, getUserListItemStyles } from '@/utils/themeUtils';
 
 interface SettingsMenuProps {
   onOpenProfile: () => void;
@@ -32,6 +33,16 @@ export default function SettingsMenu({ onOpenProfile, onLogout, onClose, onOpenR
   return (
     <Card className="fixed top-20 right-4 z-50 shadow-2xl animate-fade-in w-56 bg-card/95 backdrop-blur-md border-accent">
       <CardContent className="p-0">
+        {currentUser && (
+          <div className="p-3 border-b border-border" style={getUserListItemStyles(currentUser)}>
+            <div className="flex items-center gap-2">
+              <User className="w-4 h-4" style={{ color: getFinalUsernameColor(currentUser) }} />
+              <span className="font-semibold" style={{ color: getFinalUsernameColor(currentUser) }}>
+                {currentUser.username}
+              </span>
+            </div>
+          </div>
+        )}
         {/* القسم الأول - الملف الشخصي */}
         <div className="p-3 border-b border-border">
           <Button


### PR DESCRIPTION
Display the current user's username in the settings menu, applying their profile's color and style.

---
<a href="https://cursor.com/background-agent?bcId=bc-b083f1ba-359a-44f3-b529-2a44306c1ae2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b083f1ba-359a-44f3-b529-2a44306c1ae2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

