### PR TITLE
Fix await outside async function in chat interface

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -844,7 +844,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           isOpen={showThemeSelector}
           onClose={() => setShowThemeSelector(false)}
           currentUser={chat.currentUser}
-          onThemeUpdate={(theme) => {
+          onThemeUpdate={async (theme) => {
             if (chat.updateCurrentUser) {
               chat.updateCurrentUser({ userTheme: theme });
             }


### PR DESCRIPTION
Make `onThemeUpdate` an async function to resolve a build error caused by `await` usage.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5590e61-c5e8-4ca4-b497-0f51853186e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5590e61-c5e8-4ca4-b497-0f51853186e0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

