### PR TITLE
Extend profile image display downwards

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1034,7 +1034,7 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
 
         .profile-cover {
           position: relative;
-          aspect-ratio: 3 / 1;
+          height: 280px; /* Extended height to reach profile avatar */
           background-size: cover;
           background-position: center;
           background-repeat: no-repeat;
@@ -1104,7 +1104,7 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
           overflow: hidden;
           border: 4px solid rgba(255,255,255,0.9);
           position: absolute;
-          top: calc(100% - 65px);
+          bottom: 20px; /* Positioned at the bottom of the extended banner */
           right: 20px;
           background-color: white;
           box-shadow: 0 6px 20px rgba(0,0,0,0.6);
@@ -1125,7 +1125,7 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
 
         .change-avatar-btn {
           position: absolute;
-          top: calc(100% - 32px);
+          bottom: 25px; /* Adjusted to align with the avatar bottom position */
           right: 28px;
           background: rgba(0,0,0,0.8);
           border-radius: 50%;
@@ -1151,13 +1151,13 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
         }
 
         .profile-body {
-          padding: 72px 20px 16px;
+          padding: 20px 20px 16px; /* Reduced top padding since avatar is now inside banner */
         }
 
         .profile-info {
           margin-bottom: 12px;
           text-align: center;
-          margin-top: -50px;
+          margin-top: 0; /* Removed negative margin since avatar is inside banner */
         }
 
         .profile-info h3 {
@@ -1733,15 +1733,19 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
             max-width: 100%;
           }
           
+          .profile-cover {
+            height: 220px; /* Slightly smaller for mobile */
+          }
+          
           .profile-avatar {
             width: 100px;
             height: 100px;
-            top: calc(100% - 50px);
+            bottom: 15px; /* Adjusted for mobile */
             right: 16px;
           }
           
           .change-avatar-btn {
-            top: calc(100% - 24px);
+            bottom: 18px; /* Adjusted for mobile */
             right: 22px;
             width: 25px;
             height: 25px;
@@ -1750,7 +1754,7 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
           }
           
           .profile-body {
-            padding: 50px 12px 12px;
+            padding: 15px 12px 12px; /* Adjusted for new layout */
           }
           
           .profile-info h3 {

--- a/client/src/components/profile/ProfileBanner.tsx
+++ b/client/src/components/profile/ProfileBanner.tsx
@@ -112,7 +112,7 @@ export default function ProfileBanner({ currentUser, onBannerUpdate }: ProfileBa
   return (
     <div className="relative">
       {/* صورة البروفايل البانر */}
-      <div className="relative h-40 rounded-2xl overflow-hidden bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500 shadow-2xl border border-white/20">
+      <div className="relative h-[280px] rounded-2xl overflow-hidden bg-gradient-to-br from-indigo-600 via-purple-600 to-pink-500 shadow-2xl border border-white/20">
         {preview ? (
           <img 
             src={preview} 


### PR DESCRIPTION
Extend profile banner height and reposition avatar to fully encompass the profile picture.

---
<a href="https://cursor.com/background-agent?bcId=bc-3c428984-dac3-4949-b00e-574db5d0c833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3c428984-dac3-4949-b00e-574db5d0c833">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

