### PR TITLE
Solve user's problem

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1765,7 +1765,7 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
       
       {/* Main Modal */}
       <div className="fixed inset-0 z-50 flex items-start justify-center pt-8 pb-4 px-4 overflow-y-auto">
-        <div className={`profile-card ${selectedEffect}`} style={{ background: localUser?.profileBackgroundColor ? buildProfileBackgroundGradient(localUser.profileBackgroundColor) : undefined }}>
+        <div className={`profile-card ${selectedEffect}`} style={{ background: localUser?.profileBackgroundColor ? buildProfileBackgroundGradient(localUser.profileBackgroundColor) : undefined, backgroundBlendMode: 'normal' }}>
           {/* Close Button */}
           <button 
             onClick={onClose}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -809,7 +809,7 @@ html {
   position: absolute;
   inset: 0;
   background: inherit;
-  opacity: 1;
+  opacity: 1; /* يجب أن تبقى 1 لضمان تطابق اللون تماماً */
   z-index: -1;
 }
 
@@ -840,12 +840,12 @@ li > * > div.effect-crystal {
 .effect-shadow.has-custom-bg,
 .effect-electric.has-custom-bg,
 .effect-crystal.has-custom-bg {
-  background-blend-mode: soft-light;
+  background-blend-mode: normal;
 }
 
 /* تأثير hover محسّن للصناديق بألوان مخصصة */
 .has-custom-bg:hover {
-  filter: brightness(1.1);
+  filter: none;
 }
 
 /* التأكد من أن لون النص يظهر بوضوح على الخلفيات الملونة */


### PR DESCRIPTION
Restore original custom profile and user list background colors by disabling blending and brightening effects.

---
<a href="https://cursor.com/background-agent?bcId=bc-5932049b-f918-401f-aa9b-c61340485faa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5932049b-f918-401f-aa9b-c61340485faa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

