### PR TITLE
Solve user problem

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3217,15 +3217,20 @@ if (!existing) {
 
       const updates = req.body || {};
 
-      // Normalize profileBackgroundColor: extract first HEX if gradient provided
+      // Normalize profileBackgroundColor: allow full linear-gradient strings, otherwise sanitize HEX or fallback
       const normalizedUpdates: any = { ...updates };
       if (typeof normalizedUpdates.profileBackgroundColor === 'string') {
-        const str = String(normalizedUpdates.profileBackgroundColor);
-        const firstHex = str.match(/#[0-9A-Fa-f]{6}/)?.[0];
-        if (firstHex) {
-          normalizedUpdates.profileBackgroundColor = firstHex;
+        const str = String(normalizedUpdates.profileBackgroundColor).trim();
+        if (str.startsWith('linear-gradient(')) {
+          // keep gradient as-is
+          normalizedUpdates.profileBackgroundColor = str;
         } else if (/^#[0-9A-Fa-f]{6}$/.test(str)) {
-          // already valid
+          // valid HEX
+          normalizedUpdates.profileBackgroundColor = str;
+        } else if (/#\s*[0-9A-Fa-f]{6}/.test(str)) {
+          // extract first HEX if mixed content
+          const firstHex = str.match(/#[0-9A-Fa-f]{6}/)?.[0];
+          normalizedUpdates.profileBackgroundColor = firstHex || '#4A90E2';
         } else {
           // fallback to a safe default color if invalid
           normalizedUpdates.profileBackgroundColor = '#4A90E2';

--- a/server/utils/data-sanitizer.ts
+++ b/server/utils/data-sanitizer.ts
@@ -73,7 +73,7 @@ export function sanitizeUserData(user: any): any {
   
   return {
     ...user,
-    profileBackgroundColor: sanitizeHexColor(user.profileBackgroundColor),
+    profileBackgroundColor: sanitizeProfileBackgroundColor(user.profileBackgroundColor),
     usernameColor: sanitizeHexColor(user.usernameColor, '#000000'),
     profileEffect: sanitizeEffect(user.profileEffect),
     userTheme: sanitizeTheme(user.userTheme)
@@ -83,4 +83,21 @@ export function sanitizeUserData(user: any): any {
 // دالة لتنظيف مصفوفة من المستخدمين
 export function sanitizeUsersArray(users: any[]): any[] {
   return users.map(user => sanitizeUserData(user));
+}
+
+export function sanitizeProfileBackgroundColor(color: string | null | undefined, defaultColor: string = '#3c0d0d'): string {
+  if (!color || color === 'null' || color === 'undefined' || color === '') {
+    return defaultColor;
+  }
+  
+  const trimmed = color.trim();
+  if (trimmed.startsWith('linear-gradient(')) {
+    return trimmed;
+  }
+  
+  if (isValidHexColor(trimmed)) {
+    return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+  }
+  
+  return defaultColor;
 }


### PR DESCRIPTION
Enable profile background gradients by allowing `linear-gradient` strings to be stored and rendered, and generating gradients from single HEX colors.

The previous implementation in `server/routes.ts` normalized any `profileBackgroundColor` to its first HEX value, and `client/src/utils/themeUtils.ts`'s `buildProfileBackgroundGradient` function only returned a solid HEX color. This prevented users from having gradient profile backgrounds. The changes allow full `linear-gradient` strings to be saved and displayed, and automatically generate a subtle gradient when only a single HEX color is provided.

---
<a href="https://cursor.com/background-agent?bcId=bc-b76e4f1a-3679-44e2-a7f8-c180bb81f17a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b76e4f1a-3679-44e2-a7f8-c180bb81f17a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

