### PR TITLE
Investigate contact list color change disconnect issue

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -362,9 +362,7 @@ export default function FriendsTabPanel({
                               <span 
                                 className="text-base font-medium transition-all duration-300"
                                 style={{ 
-                                  color: getFinalUsernameColor(friend),
-                                  textShadow: getFinalUsernameColor(friend) ? `0 0 10px ${getFinalUsernameColor(friend)}40` : 'none',
-                                  filter: getFinalUsernameColor(friend) ? 'drop-shadow(0 0 3px rgba(255,255,255,0.3))' : 'none'
+                                  color: getFinalUsernameColor(friend)
                                 }}
                                 title={friend.username}
                               >
@@ -479,9 +477,7 @@ export default function FriendsTabPanel({
                                   <span 
                                     className="font-semibold"
                                     style={{ 
-                                      color: getFinalUsernameColor(request.user),
-                                      textShadow: getFinalUsernameColor(request.user) ? `0 0 10px ${getFinalUsernameColor(request.user)}40` : 'none',
-                                      filter: getFinalUsernameColor(request.user) ? 'drop-shadow(0 0 3px rgba(255,255,255,0.3))' : 'none'
+                                      color: getFinalUsernameColor(request.user)
                                     }}
                                   >
                                     {request.user.username}
@@ -557,9 +553,7 @@ export default function FriendsTabPanel({
                                   <span 
                                     className="font-semibold"
                                     style={{ 
-                                      color: getFinalUsernameColor(request.user),
-                                      textShadow: getFinalUsernameColor(request.user) ? `0 0 10px ${getFinalUsernameColor(request.user)}40` : 'none',
-                                      filter: getFinalUsernameColor(request.user) ? 'drop-shadow(0 0 3px rgba(255,255,255,0.3))' : 'none'
+                                      color: getFinalUsernameColor(request.user)
                                     }}
                                   >
                                     {request.user.username}


### PR DESCRIPTION
Remove `textShadow` and `filter: drop-shadow` from username styles to prevent Arabic characters from separating when the username color changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcd00b73-bc95-406f-a28f-9557ec8ff7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bcd00b73-bc95-406f-a28f-9557ec8ff7ac">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

