### PR TITLE
Debug online users list disconnects

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -485,6 +485,10 @@ export const useChat = () => {
           }
           
           case 'onlineUsers': {
+            const roomId = (envelope as any).roomId || 'general';
+            if (roomId !== state.currentRoomId) {
+              break;
+            }
             if (Array.isArray(envelope.users)) {
               const rawUsers = envelope.users as ChatUser[];
               // فلترة صارمة + إزالة المتجاهلين + إزالة التكرارات
@@ -498,6 +502,10 @@ export const useChat = () => {
           }
           
           case 'roomJoined': {
+            const roomId = (envelope as any).roomId;
+            if (roomId && roomId !== state.currentRoomId) {
+              break;
+            }
             // استبدال القائمة بالكامل بقائمة الغرفة المرسلة
             const users = (envelope as any).users;
             if (Array.isArray(users)) {
@@ -856,8 +864,9 @@ export const useChat = () => {
           userId: user.id,
           username: user.username,
         });
-        // طلب قائمة المتصلين فور الاتصال
-        try { s.emit('requestOnlineUsers'); lastUserListRequestAtRef.current = Date.now(); } catch {}
+        
+        // طلب قائمة المتصلين فور الاتصال - تمت الإزالة لتجنب سباق التوقيت مع الانضمام للغرفة
+        // سيتم استقبال القائمة الصحيحة عبر حدث roomJoined أو onlineUsers الخاص بالغرفة
       }
 
       // إرسال المصادقة عند الاتصال/إعادة الاتصال يتم من خلال الوحدة المشتركة
@@ -865,8 +874,7 @@ export const useChat = () => {
         dispatch({ type: 'SET_CONNECTION_STATUS', payload: true });
         dispatch({ type: 'SET_CONNECTION_ERROR', payload: null });
         dispatch({ type: 'SET_LOADING', payload: false });
-        // طلب محدث لقائمة المتصلين بعد الاتصال
-        try { s.emit('requestOnlineUsers'); lastUserListRequestAtRef.current = Date.now(); } catch {}
+        // طلب محدث لقائمة المتصلين بعد الاتصال - تمت الإزالة لتجنب سباق التوقيت
       });
 
       // معالج فشل إعادة الاتصال النهائي

--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -104,12 +104,12 @@ export function getSocket(): Socket {
     rememberUpgrade: false,
     autoConnect: false,
     reconnection: true,
-    reconnectionAttempts: Infinity,
-    reconnectionDelay: 1000,
-    reconnectionDelayMax: 60000,
+    reconnectionAttempts: 5,
+    reconnectionDelay: 3000,
+    reconnectionDelayMax: 15000,
     randomizationFactor: 0.5,
     timeout: 20000,
-    forceNew: false,
+    forceNew: true,
     withCredentials: true,
   });
 


### PR DESCRIPTION
Filter online user list updates by room ID and stabilize Socket.IO reconnection to prevent user list 'flapping'.

The online user list was "flapping" (users appearing/disappearing) because the client was updating the list with data from different rooms or due to race conditions when requesting the list immediately after connecting. Aggressive reconnection settings also contributed to unstable connections. The changes ensure updates only apply to the current room, remove problematic immediate requests, and make reconnection less aggressive and more reliable.

---
<a href="https://cursor.com/background-agent?bcId=bc-75b226b5-e0d0-4678-a51d-3009fa680888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-75b226b5-e0d0-4678-a51d-3009fa680888">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

