### PR TITLE
Check conard color database path

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -62,9 +62,9 @@ export default function ProfileModal({ user, currentUser, onClose, onIgnoreUser,
       setLocalUser(userData);
       if (onUpdate) onUpdate(userData);
       
-      // تحديث الثيم والتأثير المحلي
-      if (userData.userTheme) {
-        setSelectedTheme(userData.userTheme);
+      // تحديث لون الخلفية والتأثير المحلي
+      if (userData.profileBackgroundColor) {
+        setSelectedTheme(userData.profileBackgroundColor);
       }
       if (userData.profileEffect) {
         setSelectedEffect(userData.profileEffect);


### PR DESCRIPTION
Fix `ProfileModal` using `profileBackgroundColor` for theme selection instead of `userTheme` to resolve a type mismatch bug.

The `setSelectedTheme` function in `ProfileModal` expects a HEX color string. Previously, it was incorrectly passed `user.userTheme`, which is a theme *name* (e.g., 'golden', 'ocean'). This caused a type mismatch and incorrect behavior. `profileBackgroundColor` correctly provides a HEX color.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a67ebb4-e879-4c5a-817e-1fe95ce043eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a67ebb4-e879-4c5a-817e-1fe95ce043eb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

