### PR TITLE
Investigate duplicate image saving and chat display

### DIFF
--- a/migrations/remove_userProfileImage_from_wallPosts.sql
+++ b/migrations/remove_userProfileImage_from_wallPosts.sql
@@ -1,0 +1,4 @@
+-- حذف حقل userProfileImage من جدول wall_posts
+-- هذا الحقل غير ضروري لأننا يمكن جلب الصورة من جدول users
+
+ALTER TABLE wall_posts DROP COLUMN IF EXISTS user_profile_image;


### PR DESCRIPTION
Remove `userProfileImage` from `wall_posts` to eliminate duplicate image storage and ensure consistent profile image display.

---
<a href="https://cursor.com/background-agent?bcId=bc-d42cf91f-b99d-4e03-a9dd-babef7e61111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d42cf91f-b99d-4e03-a9dd-babef7e61111">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

