### PR TITLE
Fix profile picture and frame upload issues

### DIFF
--- a/client/src/components/chat/UserListItemWithFrame.tsx
+++ b/client/src/components/chat/UserListItemWithFrame.tsx
@@ -4,6 +4,7 @@ import { AvatarWithFrame } from '@/components/ui/AvatarWithFrame';
 import UserRoleBadge from './UserRoleBadge';
 import { cn } from '@/lib/utils';
 import { getUserListItemStyles, getUserListItemClasses } from '@/utils/themeUtils';
+import { getImageSrc } from '@/utils/imageUtils';
 
 interface UserListItemProps {
   user: ChatUser;
@@ -39,6 +40,18 @@ export const UserListItem: React.FC<UserListItemProps> = ({
     };
   }, [user.usernameColor, user.profileEffect]);
 
+  const avatarSrc = useMemo(() => {
+    const base = getImageSrc(user.profileImage, '/default_avatar.svg');
+    const v = (user as any).avatarHash || (user as any).avatarVersion;
+    if (base && v && typeof v === 'string' && !base.includes('?v=')) {
+      return `${base}?v=${v}`;
+    }
+    if (base && v && typeof v === 'number' && !base.includes('?v=')) {
+      return `${base}?v=${v}`;
+    }
+    return base;
+  }, [user.profileImage, (user as any)?.avatarHash, (user as any)?.avatarVersion]);
+
   return (
     <li
       onClick={onClick}
@@ -52,7 +65,7 @@ export const UserListItem: React.FC<UserListItemProps> = ({
     >
       {/* الصورة الشخصية مع الإطار */}
       <AvatarWithFrame
-        src={(user.profileImage && (user as any).avatarHash) ? `${user.profileImage}?v=${(user as any).avatarHash}` : (user.profileImage || '/default_avatar.svg')}
+        src={avatarSrc}
         alt={user.username}
         fallback={user.username.substring(0, 2).toUpperCase()}
         frame={user.avatarFrame}

--- a/client/src/components/chat/UserPopup.tsx
+++ b/client/src/components/chat/UserPopup.tsx
@@ -51,7 +51,7 @@ export default function UserPopup({
     try {
       await apiRequest(`/api/users/${user.id}/avatar-frame`, {
         method: 'POST',
-        body: { frame: selectedFrame }
+        body: { frame: selectedFrame, moderatorId: currentUser.id }
       });
       
       toast({


### PR DESCRIPTION
Fixes profile images not displaying/updating in the online list and enables owner-moderated avatar frame updates.

Profile images in the online list were failing to load or update due to a duplicate `?v=` query parameter. Avatar frame updates for other users were failing for owners because the `moderatorId` was not being sent, preventing the request from passing the `protect.owner` middleware and broadcasting the change.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8297265-a171-4568-83dd-c3d8c82773a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8297265-a171-4568-83dd-c3d8c82773a1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

