### PR TITLE
Investigate add frame button functionality

### DIFF
--- a/client/src/components/chat/UserPopup.tsx
+++ b/client/src/components/chat/UserPopup.tsx
@@ -180,6 +180,9 @@ export default function UserPopup({
         top: `${y}px`,
         left: `${x - 160}px`,
       }}
+      onClick={(e) => e.stopPropagation()}
+      onMouseDown={(e) => e.stopPropagation()}
+      onTouchStart={(e) => e.stopPropagation()}
     >
       <Button
         onClick={onViewProfile}


### PR DESCRIPTION
Prevent `UserPopup` from closing immediately when clicking "Add Frame".

The `UserPopup` was closing due to event propagation to a parent listener, which prevented the frame selection dialog from appearing. Adding `stopPropagation` to the popup's click, mousedown, and touchstart events ensures the dialog can open correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-c160531f-e138-4f15-9a2d-bee12f7a7d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c160531f-e138-4f15-9a2d-bee12f7a7d31">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

