### PR TITLE
إصلاح تبويب إدارة المالك وعرض المشرفين

### DIFF
--- a/client/src/components/chat/OwnerAdminPanel.tsx
+++ b/client/src/components/chat/OwnerAdminPanel.tsx
@@ -75,13 +75,24 @@ export default function OwnerAdminPanel({
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { toast } = useToast();
 
+  // مزامنة الحالة المحلية مع الخاصية القادمة من المكوّن الأب (إن وُجدت)
   useEffect(() => {
-    if (isOpen && currentUser?.userType === 'owner') {
-      setIsModalOpen(isOpen);
-      fetchModerationData();
-      fetchStaffMembers();
+    setIsModalOpen(Boolean(isOpen));
+  }, [isOpen]);
+
+  // جلب البيانات عند فتح النافذة فعلياً
+  useEffect(() => {
+    if (isModalOpen && currentUser?.userType === 'owner') {
+      // جلب بحسب التبويب الحالي لتجنب طلبات غير لازمة
+      if (selectedTab === 'log') {
+        fetchModerationData();
+      } else if (selectedTab === 'staff') {
+        fetchStaffMembers();
+      } else {
+        // تبويب الحظر لا يحتاج جلب أولي هنا
+      }
     }
-  }, [isOpen, currentUser]);
+  }, [isModalOpen, currentUser, selectedTab]);
 
   const fetchModerationData = async () => {
     if (!currentUser) return;


### PR DESCRIPTION
Fixes Owner Management tab to correctly display moderator lists and action logs.

The previous data fetching logic for the Owner Management panel was inconsistent, causing the moderator list and action log to not always appear. This PR refactors the `useEffect` hooks to correctly synchronize the modal's open state and to trigger data fetching specifically for the active tab when the modal is opened, ensuring proper content display and preventing unnecessary API calls.

---
<a href="https://cursor.com/background-agent?bcId=bc-7b818699-3112-48b4-b993-11b1f2e782a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7b818699-3112-48b4-b993-11b1f2e782a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

