### PR TITLE
Delete message notifications completely

### DIFF
--- a/client/src/components/chat/NotificationPanel.tsx
+++ b/client/src/components/chat/NotificationPanel.tsx
@@ -168,7 +168,9 @@ export default function NotificationPanel({
     refetch();
   }, [refetch]);
 
-  const notifications = notificationsData?.notifications || [];
+  const allNotifications = notificationsData?.notifications || [];
+  // استبعاد إشعارات الرسائل نهائياً من الواجهة (حماية إضافية بجانب فلترة الخادم)
+  const notifications = allNotifications.filter((n) => n.type !== 'message');
   const unreadCount = unreadCountData?.count || 0;
 
   const getNotificationIcon = (type: string) => {

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1326,13 +1326,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           .to(senderId.toString())
           .emit('privateMessage', { message: { ...message, sender } });
 
-        // إنشاء إشعار في قاعدة البيانات للمستقبل
-        await notificationService.createMessageNotification(
-          receiverId,
-          sender.username,
-          senderId,
-          content.substring(0, 100) // معاينة من الرسالة
-        );
+        // تم إيقاف إنشاء إشعار الرسائل: تبويب الإشعارات لا يعرض إشعارات الرسائل
       } else {
         // رسالة عامة
         getIO().emit('message', {

--- a/server/routes/privateMessages.ts
+++ b/server/routes/privateMessages.ts
@@ -83,12 +83,7 @@ router.post('/send', protect.auth, async (req, res) => {
     // إرسال إشعار وبث الرسالة بشكل متوازي
     const promises = [];
 
-    // إنشاء إشعار للمستقبل
-    promises.push(
-      notificationService
-        .createMessageNotification(receiver.id, sender.username, sender.id, text.substring(0, 100))
-        .catch(() => null)
-    );
+    // تم إيقاف إنشاء إشعار الرسائل: تبويب الإشعارات لا يعرض إشعارات الرسائل
 
     // بث الرسالة عبر Socket.IO
     const io = req.app.get('io');

--- a/server/services/notificationService.ts
+++ b/server/services/notificationService.ts
@@ -1,4 +1,4 @@
-import { eq, desc, and } from 'drizzle-orm';
+import { eq, desc, and, not } from 'drizzle-orm';
 
 import { notifications, type Notification, type InsertNotification } from '../../shared/schema';
 import { db } from '../database-adapter';
@@ -25,7 +25,7 @@ export class NotificationService {
       const userNotifications = await db
         .select()
         .from(notifications)
-        .where(eq(notifications.userId, userId))
+        .where(and(eq(notifications.userId, userId), not(eq(notifications.type, 'message' as any))))
         .orderBy(desc(notifications.createdAt))
         .limit(limit);
 
@@ -84,7 +84,13 @@ export class NotificationService {
       const unreadNotifications = await db
         .select()
         .from(notifications)
-        .where(and(eq(notifications.userId, userId), eq(notifications.isRead, false)));
+        .where(
+          and(
+            eq(notifications.userId, userId),
+            eq(notifications.isRead, false),
+            not(eq(notifications.type, 'message' as any))
+          )
+        );
 
       return unreadNotifications.length;
     } catch (error) {


### PR DESCRIPTION
Remove message notifications from the general notifications tab and backend logic.

Message notifications are handled via a separate dedicated path and should not appear in the main notification panel. This PR stops their creation, excludes them from API fetches, and filters them on the client side.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b3697ae-55e7-4823-82df-81e7e1cadd19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9b3697ae-55e7-4823-82df-81e7e1cadd19">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

