### PR TITLE
Refactor message filtering to reduce aggression

### DIFF
--- a/server/security.ts
+++ b/server/security.ts
@@ -122,17 +122,10 @@ export function validateMessageContent(content: string): { isValid: boolean; rea
     };
   }
 
-  // Check for spam patterns
-  const spamPatterns = [
-    /(.)\1{10,}/gi, // Repeated characters
-    /https?:\/\/[^\s]+/gi, // URLs (adjust based on your needs)
-    /[^\w\s\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/gi, // Non-Arabic/alphanumeric chars (allowing Arabic)
-  ];
-
-  for (const pattern of spamPatterns) {
-    if (pattern.test(trimmedContent)) {
-      return { isValid: false, reason: 'المحتوى يحتوي على نص مشبوه' };
-    }
+  // Filter only links (URLs)
+  const linkPattern = /https?:\/\/[^\s]+/gi;
+  if (linkPattern.test(trimmedContent)) {
+    return { isValid: false, reason: 'الروابط غير مسموح بها في الدردشة' };
   }
 
   return { isValid: true };

--- a/server/spam-protection.ts
+++ b/server/spam-protection.ts
@@ -1,8 +1,5 @@
 // نظام مكافحة السبام
 export interface SpamProtectionConfig {
-  maxMessageLength: number;
-  minMessageLength: number;
-  bannedWords: string[];
   maxDuplicateMessages: number;
   duplicateTimeWindow: number; // بالميلي ثانية
 }
@@ -37,12 +34,6 @@ export class SpamProtection {
 
   constructor() {
     this.config = {
-      maxMessageLength: 1000,
-      minMessageLength: 1,
-      bannedWords: [
-        // كلمات محظورة أساسية فقط
-        'سبام',
-      ],
       maxDuplicateMessages: 10, // زيادة الحد المسموح
       duplicateTimeWindow: 30000, // 30 ثانية فقط
     };

--- a/server/spam-protection.ts
+++ b/server/spam-protection.ts
@@ -61,7 +61,19 @@ export class SpamProtection {
     reason?: string;
     action?: 'warn' | 'tempBan' | 'ban';
   } {
-    // السماح بجميع الرسائل بدون فحص مؤقتاً
+    // تفعيل فحص التكرار فقط
+    const duplicateCheck = this.checkDuplicateMessage(userId, content);
+    if (!duplicateCheck.isAllowed) {
+      return {
+        isAllowed: false,
+        reason: duplicateCheck.reason,
+        action: duplicateCheck.action,
+      };
+    }
+
+    // إضافة الرسالة للسجل بعد الفحص
+    this.addMessage(userId, content);
+
     return { isAllowed: true };
   }
 

--- a/server/utils/adult-content.ts
+++ b/server/utils/adult-content.ts
@@ -1,0 +1,98 @@
+// فحص مبسط للصور لمنع المحتوى الجنسي باستخدام تحليل نسبة لون الجلد
+// يعتمد على Heuristics بدون مكتبات ثقيلة، باستخدام sharp لتحويل الصورة إلى بيانات RAW
+
+import sharp from 'sharp';
+
+export type AdultCheckResult = {
+  isSexual: boolean;
+  skinRatio: number;
+  width: number;
+  height: number;
+};
+
+// تحويل RGB إلى YCbCr للتعرف على لون الجلد (تقريبي)
+function rgbToYCbCr(r: number, g: number, b: number) {
+  // الصيغ التقريبية القياسية
+  const y = 0.299 * r + 0.587 * g + 0.114 * b;
+  const cb = 128 - 0.168736 * r - 0.331264 * g + 0.5 * b;
+  const cr = 128 + 0.5 * r - 0.418688 * g - 0.081312 * b;
+  return { y, cb, cr };
+}
+
+// اكتشاف بكسلات الجلد باستخدام عتبات YCbCr + فلترة بسيطة على HSV لتقليل الإيجابيات الكاذبة
+function isSkinPixel(r: number, g: number, b: number): boolean {
+  const { cb, cr } = rgbToYCbCr(r, g, b);
+  // عتبات شائعة للجلد في YCbCr
+  const inYCbCrRange = cb >= 77 && cb <= 127 && cr >= 133 && cr <= 173;
+
+  // فلترة HSV المساعدة
+  const max = Math.max(r, g, b);
+  const min = Math.min(r, g, b);
+  const v = max / 255;
+  const s = max === 0 ? 0 : (max - min) / max;
+  let h = 0;
+  if (max === min) {
+    h = 0;
+  } else if (max === r) {
+    h = ((g - b) / (max - min)) * 60;
+  } else if (max === g) {
+    h = (2 + (b - r) / (max - min)) * 60;
+  } else {
+    h = (4 + (r - g) / (max - min)) * 60;
+  }
+  if (h < 0) h += 360;
+
+  // نطاق لون الجلد في HSV تقريبي: H بين 0 و 50، S متوسط، V متوسط/مرتفع
+  const inHSVRange = h >= 0 && h <= 50 && s >= 0.23 && s <= 0.9 && v >= 0.35;
+
+  return inYCbCrRange && inHSVRange;
+}
+
+export async function detectSexualImage(
+  buffer: Buffer,
+  opts?: { strict?: boolean; downscaleTo?: number; threshold?: number }
+): Promise<AdultCheckResult> {
+  const strict = opts?.strict ?? (process.env.ADULT_CONTENT_STRICT === 'true');
+  const sampleSize = Math.max(32, Math.min(128, opts?.downscaleTo ?? 96));
+  const threshold = Math.min(0.9, Math.max(0.05, opts?.threshold ?? (strict ? 0.28 : 0.38)));
+
+  try {
+    const { data, info } = await sharp(buffer)
+      .removeAlpha()
+      .resize({ width: sampleSize, height: sampleSize, fit: 'inside' })
+      .ensureAlpha()
+      .toColourspace('srgb')
+      .raw()
+      .toBuffer({ resolveWithObject: true } as any);
+
+    const channels = info.channels; // قد تكون 4 بسبب ensureAlpha
+    const width = info.width;
+    const height = info.height;
+    const totalPixels = width * height;
+    if (!totalPixels || channels < 3) {
+      return { isSexual: false, skinRatio: 0, width, height };
+    }
+
+    let skinCount = 0;
+    for (let i = 0; i < data.length; i += channels) {
+      const r = data[i];
+      const g = data[i + 1];
+      const b = data[i + 2];
+      if (isSkinPixel(r, g, b)) skinCount++;
+    }
+
+    const skinRatio = skinCount / totalPixels;
+    const isSexual = skinRatio >= threshold;
+    return { isSexual, skinRatio, width, height };
+  } catch (error) {
+    // في حالة فشل التحليل، لا نمنع بشكل صلب، بل نسمح مع تسجيل ملاحظة
+    return { isSexual: false, skinRatio: 0, width: 0, height: 0 };
+  }
+}
+
+// مبدئياً الفيديو غير مدعوم للرفع في النظام (مصفي MIME يمنع الفيديو)،
+// إن تمت إضافة رفع فيديو لاحقاً يمكن فحص لقطات من الفيديو هنا.
+export async function detectSexualVideo(_buffer: Buffer): Promise<AdultCheckResult> {
+  return { isSexual: false, skinRatio: 0, width: 0, height: 0 };
+}
+


### PR DESCRIPTION
Reduce message filtering to only block links and repeated content.

The previous filtering was overly aggressive, leading to legitimate messages being blocked. This change aligns the system with user feedback, allowing more freedom in message content while still preventing spam links and excessive message repetition.

---
<a href="https://cursor.com/background-agent?bcId=bc-e98d20c4-67bd-4bcf-97aa-2ae4c3ee3b72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e98d20c4-67bd-4bcf-97aa-2ae4c3ee3b72">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

