### PR TITLE
Update wealthy user display names

### DIFF
--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -4,6 +4,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { getSocket } from '@/lib/socket';
 import type { ChatUser } from '@/types/chat';
 import { getImageSrc } from '@/utils/imageUtils';
+import { getFinalUsernameColor } from '@/utils/themeUtils';
 
 interface RichestModalProps {
   isOpen: boolean;
@@ -135,8 +136,15 @@ export default function RichestModal({ isOpen, onClose, currentUser }: RichestMo
 
                 {/* اسم المستخدم */}
                 <div className="flex-1">
-                  <div className="font-medium" style={{ color: u.usernameColor || '#000000' }}>
-                    {u.username}
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="text-base font-medium transition-colors duration-300"
+                      style={{ color: getFinalUsernameColor(u) }}
+                      title={u.username}
+                    >
+                      {u.username}
+                    </span>
+                    {u.isMuted && <span className="text-yellow-400 text-xs">🔇</span>}
                   </div>
                 </div>
 


### PR DESCRIPTION
Align username display in the Richest tab with the online users list for consistent styling and features.

---
<a href="https://cursor.com/background-agent?bcId=bc-5a656953-04d4-43a0-8049-707fb89e6ea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5a656953-04d4-43a0-8049-707fb89e6ea0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

