### PR TITLE
Compare contact, friends, and rich lists

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -395,7 +395,7 @@ export default function FriendsTabPanel({
                       showModerationActions={isModerator}
                     >
                       <div
-                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-gray-200 transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(friend) || 'bg-white hover:bg-gray-50'}`}
+                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-border transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(friend) || 'bg-card hover:bg-accent/10'}`}
                         style={getUserListItemStyles(friend)}
                         onClick={(e) => onStartPrivateChat(friend)}
                       >


### PR DESCRIPTION
Unify friends list item styling to match other user lists.

The friends list item was using hard-coded `bg-white`, `hover:bg-gray-50`, and `border-gray-200` classes, leading to an inconsistent UI and poor dark mode compatibility compared to other user lists that correctly used theme-based `bg-card`, `hover:bg-accent/10`, and `border-border`. This change resolves the styling duplication.

---
<a href="https://cursor.com/background-agent?bcId=bc-99c0f04d-297d-44fa-9910-18b6b292fc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99c0f04d-297d-44fa-9910-18b6b292fc89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

