### PR TITLE
Is the system ready

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3434,6 +3434,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       level: sanitized.level,
       totalPoints: sanitized.totalPoints,
       levelProgress: sanitized.levelProgress,
+      gender: sanitized.gender,
+      country: sanitized.country,
+      isMuted: sanitized.isMuted,
     };
     if (
       sanitized.profileImage &&

--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -506,11 +506,17 @@ export class DatabaseService {
             userType: schema.users.userType,
             role: schema.users.role,
             profileImage: schema.users.profileImage,
+            profileBackgroundColor: schema.users.profileBackgroundColor,
+            profileEffect: schema.users.profileEffect,
+            usernameColor: schema.users.usernameColor,
             isOnline: schema.users.isOnline,
             lastSeen: schema.users.lastSeen,
             points: schema.users.points,
             level: schema.users.level,
             totalPoints: schema.users.totalPoints,
+            gender: schema.users.gender,
+            country: schema.users.country,
+            isMuted: schema.users.isMuted,
           })
           .from(schema.users)
           .innerJoin(schema.vipUsers, eq(schema.vipUsers.userId, schema.users.id))
@@ -572,7 +578,24 @@ export class DatabaseService {
     try {
       if (this.type === 'postgresql') {
         return await (this.db as any)
-          .select()
+          .select({
+            id: schema.users.id,
+            username: schema.users.username,
+            userType: schema.users.userType,
+            role: schema.users.role,
+            profileImage: schema.users.profileImage,
+            profileBackgroundColor: schema.users.profileBackgroundColor,
+            profileEffect: schema.users.profileEffect,
+            usernameColor: schema.users.usernameColor,
+            isOnline: schema.users.isOnline,
+            lastSeen: schema.users.lastSeen,
+            points: schema.users.points,
+            level: schema.users.level,
+            totalPoints: schema.users.totalPoints,
+            gender: schema.users.gender,
+            country: schema.users.country,
+            isMuted: schema.users.isMuted,
+          })
           .from(schema.users)
           .where(
             or(eq(schema.users.userType, 'owner' as any), eq(schema.users.userType, 'admin' as any))


### PR DESCRIPTION
Fetch user profile colors and effects for VIP users to ensure consistent display in the Rich List.

Previously, the `getVipUsers` and `getVipCandidates` functions did not retrieve `profileBackgroundColor`, `profileEffect`, or `usernameColor`, causing user boxes in the Rich List to display default colors instead of their customized ones. This PR updates these functions and the `buildUserBroadcastPayload` to include these fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-cecfa737-0df9-4fd4-b32e-6131a2a2ddf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cecfa737-0df9-4fd4-b32e-6131a2a2ddf3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

