### PR TITLE
Investigate chat functionality breakdown on tab navigation

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -681,7 +681,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             </Suspense>
           </div>
         )}
-        {!isMobile || activeView === 'hidden'
+        {!isMobile || activeView === 'hidden' || showNotifications || showRichest || showMessages || showPmBox || showProfile || showSettings || showReportModal || showAdminReports || showModerationPanel || showOwnerPanel || showReportsLog || showActiveActions || showPromotePanel || showThemeSelector || showUsernameColorPicker || showIgnoredUsers
           ? (() => {
               const currentRoom = rooms.find((room) => room.id === chat.currentRoomId);
 


### PR DESCRIPTION
Update chat visibility condition to ensure the chat area remains visible on mobile when various modals are open.

The original condition `{!isMobile || activeView === 'hidden'}` caused the chat area to disappear on mobile devices when modals (e.g., notifications, richest users) were opened. This was because these modals do not set `activeView` to `'hidden'`, thus failing the condition. The updated condition explicitly checks for the visibility of these modals, allowing the chat to persist in the background.

---
<a href="https://cursor.com/background-agent?bcId=bc-c928c41a-a328-48db-98be-cd083dbdf695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c928c41a-a328-48db-98be-cd083dbdf695">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

