### PR TITLE
Fixing chat connection and navigation issues

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -102,6 +102,11 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     cacheTimeout: 10 * 60 * 1000, // 10 دقائق cache
   });
 
+  // جلب الغرف عند الدخول لأول مرة لضمان ظهور التبويب مباشرة
+  useEffect(() => {
+    fetchRooms(false).catch(() => {});
+  }, [fetchRooms]);
+
   // 🚀 دوال إدارة الغرف المحسنة
   const handleRoomChange = useCallback(
     async (roomId: string) => {
@@ -170,6 +175,24 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     setNewRoomDescription('');
     setNewRoomImage(null);
   }, [handleAddRoom, newRoomName, newRoomDescription, newRoomImage]);
+
+  // الاستماع لتحديثات الغرف عبر Socket.IO من خلال حدث roomUpdate
+  useEffect(() => {
+    try {
+      const { getSocket } = require('@/lib/socket');
+      const s = getSocket();
+      const onRoomUpdate = (_payload: any) => {
+        // جلب مُجبر لتحديث القائمة فوراً
+        fetchRooms(true).catch(() => {});
+      };
+      s.on('roomUpdate', onRoomUpdate);
+      return () => {
+        try { s.off('roomUpdate', onRoomUpdate); } catch {}
+      };
+    } catch {
+      // ignore if socket not available
+    }
+  }, [fetchRooms]);
 
   const [showNotifications, setShowNotifications] = useState(false);
 

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1254,6 +1254,20 @@ export const useChat = () => {
           dispatch({ type: 'SET_CONNECTION_ERROR', payload: null });
           dispatch({ type: 'SET_LOADING', payload: false });
 
+          // إعادة إرسال المصادقة والانضمام للغرفة لضمان الاتصال الصحيح
+          try {
+            s.emit('auth', {
+              userId: user.id,
+              username: user.username,
+              userType: user.userType,
+            });
+            s.emit('joinRoom', {
+              roomId: state.currentRoomId || 'general',
+              userId: user.id,
+              username: user.username,
+            });
+          } catch {}
+
           // Prefetch expected data shortly after connection success
           try {
             // غُصن خفيف لتفادي إزعاج الشبكة فوراً

--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -40,12 +40,11 @@ export function clearSession() {
     socketInstance.removeAllListeners();
     socketInstance.disconnect();
     socketInstance = null;
-    listenersAttached = false;
+    // listeners are scoped to instance via a private flag now
   }
 }
 
 let socketInstance: Socket | null = null;
-let listenersAttached = false;
 
 function getServerUrl(): string {
   try {
@@ -63,8 +62,9 @@ function getServerUrl(): string {
 }
 
 function attachCoreListeners(socket: Socket) {
-  if (listenersAttached) return;
-  listenersAttached = true;
+  const anySocket = socket as any;
+  if (anySocket.__coreListenersAttached) return;
+  anySocket.__coreListenersAttached = true;
 
   const reauth = (isReconnect: boolean) => {
     const session = getSession();
@@ -115,7 +115,7 @@ export function getSocket(): Socket {
     socketInstance.removeAllListeners();
     socketInstance.disconnect();
     socketInstance = null;
-    listenersAttached = false;
+    // listeners are scoped to instance via a private flag now
   }
 
   if (socketInstance) return socketInstance;


### PR DESCRIPTION
Refactor Socket listeners to be instance-specific and re-send authentication/room join on connect to ensure robust connection handling and resolve intermittent chat issues.

Previously, a global flag prevented core Socket listeners from being re-attached after a full disconnect, leading to silent failures. Additionally, the client did not re-authenticate or re-join the room upon reconnection. These changes ensure that listeners are always correctly set up for each socket instance and that the client reliably re-establishes its authenticated state and room membership after any connection event, addressing intermittent chat and room navigation failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-de326fd7-6f31-4a04-968c-1ca28e9fe49c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-de326fd7-6f31-4a04-968c-1ca28e9fe49c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

