### PR TITLE
Send welcome message

### DIFF
--- a/client/src/components/chat/AnimatedEmojiPicker.tsx
+++ b/client/src/components/chat/AnimatedEmojiPicker.tsx
@@ -51,6 +51,11 @@ export default function AnimatedEmojiPicker({ onEmojiSelect, onClose }: Animated
                     alt={emoji.name}
                     className="w-8 h-8 object-contain"
                     loading="lazy"
+                    onError={(e: any) => {
+                      if (e?.currentTarget && e.currentTarget.src !== '/svgs/star.svg') {
+                        e.currentTarget.src = '/svgs/star.svg';
+                      }
+                    }}
                   />
                 </Button>
               ))}

--- a/client/src/utils/animatedEmojiUtils.tsx
+++ b/client/src/utils/animatedEmojiUtils.tsx
@@ -25,6 +25,11 @@ export function parseAnimatedEmojis(text: string): React.ReactNode[] {
         alt={emojiId}
         className="inline-block w-8 h-8 mx-1 align-middle animated-emoji"
         loading="lazy"
+        onError={(e: any) => {
+          if (e?.currentTarget && e.currentTarget.src !== '/svgs/star.svg') {
+            e.currentTarget.src = '/svgs/star.svg';
+          }
+        }}
       />
     );
     


### PR DESCRIPTION
Add `onError` fallback to animated emojis to display a default icon when GIF files are missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-488cde06-deec-4669-9b1b-39b294faf357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-488cde06-deec-4669-9b1b-39b294faf357">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

