### PR TITLE
Build failed due to unresolved lottie player import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@emoji-mart/react": "^1.1.1",
         "@hookform/resolvers": "^3.10.0",
         "@jridgewell/trace-mapping": "^0.3.25",
+        "@lottiefiles/react-lottie-player": "^3.6.0",
         "@neondatabase/serverless": "^0.10.4",
         "@radix-ui/react-accordion": "^1.2.4",
         "@radix-ui/react-alert-dialog": "^1.1.7",
@@ -2397,6 +2398,18 @@
         "@jscpd/core": "4.0.1",
         "reprism": "^0.0.11",
         "spark-md5": "^3.0.2"
+      }
+    },
+    "node_modules/@lottiefiles/react-lottie-player": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@lottiefiles/react-lottie-player/-/react-lottie-player-3.6.0.tgz",
+      "integrity": "sha512-WK5TriLJT93VF3w4IjSVyveiedraZCnDhKzCPhpbeLgQeMi6zufxa3dXNc4HmAFRXq+LULPAy+Idv1rAfkReMA==",
+      "license": "MIT",
+      "dependencies": {
+        "lottie-web": "^5.12.2"
+      },
+      "peerDependencies": {
+        "react": "16 - 19"
       }
     },
     "node_modules/@neondatabase/serverless": {

--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.55.0",
     "react-icons": "^5.4.0",
+    "@lottiefiles/react-lottie-player": "^3.6.0",
     "react-lottie-player": "^2.1.0",
     "react-resizable-panels": "^2.1.7",
     "react-virtuoso": "^4.14.0",


### PR DESCRIPTION
Add `@lottiefiles/react-lottie-player` dependency to resolve build failure due to missing module.

---
<a href="https://cursor.com/background-agent?bcId=bc-01b4121a-7108-4c29-a805-bf6f3d118a29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-01b4121a-7108-4c29-a805-bf6f3d118a29">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

