### PR TITLE
Is the system ready

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -14,6 +14,7 @@ import {
   getFinalUsernameColor,
   buildProfileBackgroundGradient,
 } from '@/utils/themeUtils';
+import { getUserLevelIcon } from '@/components/chat/UserRoleBadge';
 
 interface ProfileModalProps {
   user: ChatUser | null;


### PR DESCRIPTION
Add missing import for `getUserLevelIcon` to fix white screen when opening the profile modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e0c9542-58ed-4bf4-90ce-62df94e0076b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e0c9542-58ed-4bf4-90ce-62df94e0076b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

