### PR TITLE
Is the system ready

### DIFF
--- a/client/src/components/chat/ComposerPlusMenu.tsx
+++ b/client/src/components/chat/ComposerPlusMenu.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Plus, Image, Bold, Palette } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useComposerStyle } from '@/contexts/ComposerStyleContext';
+
+interface ComposerPlusMenuProps {
+  onOpenImagePicker?: () => void;
+  disabled?: boolean;
+  isMobile?: boolean;
+}
+
+export default function ComposerPlusMenu({ onOpenImagePicker, disabled, isMobile }: ComposerPlusMenuProps) {
+  const { toggleBold, setTextColor, palette, bold } = useComposerStyle();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={disabled}
+          className={`aspect-square mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''}`}
+        >
+          <Plus className="w-4 h-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-[12rem]">
+        <DropdownMenuLabel>خيارات إضافية</DropdownMenuLabel>
+        <DropdownMenuItem onClick={() => onOpenImagePicker && onOpenImagePicker()}>
+          <Image className="w-4 h-4 ml-2" />
+          إرسال صورة
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={toggleBold}>
+          <Bold className="w-4 h-4 ml-2" />
+          نص غامق {bold ? '✔️' : ''}
+        </DropdownMenuItem>
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>
+            <Palette className="w-4 h-4 ml-2" />
+            لون النص
+          </DropdownMenuSubTrigger>
+          <DropdownMenuSubContent className="p-2">
+            <div className="grid grid-cols-6 gap-2">
+              {palette.map((color) => (
+                <button
+                  key={color}
+                  onClick={() => setTextColor(color)}
+                  className="w-5 h-5 rounded border border-gray-300 hover:scale-110 transition-transform"
+                  style={{ backgroundColor: color }}
+                  title={color}
+                />
+              ))}
+            </div>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1,4 +1,4 @@
-import { Send, Smile, ChevronDown, Sparkles, Plus } from 'lucide-react';
+import { Send, Smile, ChevronDown, Sparkles } from 'lucide-react';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1,4 +1,4 @@
-import { Send, Smile, ChevronDown, Sparkles } from 'lucide-react';
+import { Send, Smile, ChevronDown, Sparkles, Plus } from 'lucide-react';
 import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { Virtuoso, type VirtuosoHandle } from 'react-virtuoso';
 

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -7,6 +7,7 @@ const AnimatedEmojiPicker = React.lazy(() => import('./AnimatedEmojiPicker'));
 const EmojiMartPicker = React.lazy(() => import('./EmojiMartPicker'));
 const LottieEmojiPicker = React.lazy(() => import('./LottieEmojiPicker'));
 const AnimatedEmojiEnhanced = React.lazy(() => import('./AnimatedEmojiEnhanced'));
+const ComposerPlusMenu = React.lazy(() => import('./ComposerPlusMenu'));
 import ProfileImage from './ProfileImage';
 import UserRoleBadge from './UserRoleBadge';
 
@@ -856,7 +857,14 @@ export default function MessageArea({
             )}
           </div>
 
-          {/* Removed ComposerPlusMenu (gallery/color/bold) */}
+          {/* Composer Plus Menu */}
+          <React.Suspense fallback={null}>
+            <ComposerPlusMenu
+              onOpenImagePicker={() => fileInputRef.current?.click()}
+              disabled={!currentUser}
+              isMobile={isMobile}
+            />
+          </React.Suspense>
 
           {/* Message Input */}
           <Input


### PR DESCRIPTION
Re-add the `ComposerPlusMenu` component to restore the missing plus button with image, bold, and color options in the chat input.

The `ComposerPlusMenu` component was previously removed (as indicated by a comment in `MessageArea.tsx`). This PR restores the component and integrates it back into the chat input area, addressing the user's report of the missing functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-70230795-e004-489c-98e3-edd7c5f9c079">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70230795-e004-489c-98e3-edd7c5f9c079">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

