### PR TITLE
Investigate session context saving bug

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -388,7 +388,7 @@ export default function FriendsTabPanel({
             ) : (
               <ul className="space-y-0">
                 {filteredFriends.map((friend) => (
-                  <li key={friend.id} className="relative -mx-4">
+                  <li key={friend.id} className="relative -mx-4 list-none">
                     <SimpleUserMenu
                       targetUser={friend}
                       currentUser={currentUser}

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -499,7 +499,7 @@ export default function UnifiedSidebar({
       React.memo(({ user }: { user: ChatUser }) => {
         if (!user?.username || !user?.userType) return null;
         return (
-          <li key={user.id} className="relative">
+          <li key={user.id} className="relative list-none">
             <SimpleUserMenu
               targetUser={user}
               currentUser={currentUser}

--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -247,7 +247,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
 
           <ul className="space-y-1">
             {topTen.map((u, idx) => (
-              <li key={u.id} className="relative -mx-4">
+              <li key={u.id} className="relative -mx-4 list-none">
                 <SimpleUserMenu targetUser={u} currentUser={currentUser || null} showModerationActions={isModerator}>
                   <div
                     className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(u) || 'bg-card hover:bg-accent/10'}`}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2018,3 +2018,10 @@ li::before {
 .users-list-reset li::before {
   content: '';
 }
+
+/* Fix for user list items in sidebar - remove pseudo element */
+.users-list-reset li::before,
+#root li[class*="relative"]::before {
+  content: none !important;
+  display: none !important;
+}


### PR DESCRIPTION
Remove an unwanted white dot appearing between user list items due to a global `li::before` CSS rule.

A global `li::before` rule was adding a '◈' character to all `<li>` elements. This character rendered inconsistently across browsers (white dot in Chrome/mobile, invisible in Firefox) and sometimes overlapped with profile images on mobile. This PR adds specific CSS to override this rule for user list items and adds `list-none` to affected `<li>` elements to prevent the unwanted pseudo-element from appearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-27e8bd31-86a2-425e-959c-e8d62b35cd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27e8bd31-86a2-425e-959c-e8d62b35cd08">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

