### PR TITLE
Build and deploy rest-express project

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -13,6 +13,7 @@ import { developmentOnly, logDevelopmentEndpoint } from './middleware/developmen
 import { sanitizeUserData, sanitizeUsersArray } from './utils/data-sanitizer';
 
 import bcrypt from 'bcrypt';
+import express from 'express';
 import type { Express } from 'express';
 import multer from 'multer';
 import sharp from 'sharp';


### PR DESCRIPTION
Add missing `express` import in `server/routes.ts` to fix `ReferenceError: express is not defined` during server startup.

The server was failing to start in production due to `express.json()` being called without `express` being explicitly imported in `server/routes.ts`, leading to a `ReferenceError`. Adding `import express from 'express';` resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-f8d12e0e-7571-432c-8d8f-e04253dc2ee0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f8d12e0e-7571-432c-8d8f-e04253dc2ee0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

