### PR TITLE
Fix frame appearance and boundaries

### DIFF
--- a/client/src/components/chat/ProfileImage.tsx
+++ b/client/src/components/chat/ProfileImage.tsx
@@ -61,16 +61,18 @@ export default function ProfileImage({
   }, [user.profileImage, (user as any)?.avatarHash, (user as any)?.avatarVersion]);
 
   return (
-    <div className="relative inline-block" onClick={onClick}>
+    <div className={`relative inline-block ${sizeClasses[size]} rounded-full overflow-hidden`} onClick={onClick}>
       {/* إطار متدرج إذا كان متوفرًا */}
       {gradientBorder && (
         <div 
-          className={`absolute inset-0 ${sizeClasses[size]} rounded-full`}
+          className={`absolute inset-0 rounded-full pointer-events-none`}
           style={{
             background: gradientBorder,
             padding: '3px',
-            WebkitMaskImage: 'radial-gradient(circle, transparent 65%, black 65%)',
-            maskImage: 'radial-gradient(circle, transparent 65%, black 65%)',
+            boxSizing: 'border-box',
+            WebkitMask: 'linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0)',
+            WebkitMaskComposite: 'xor',
+            maskComposite: 'exclude',
           }}
         />
       )}
@@ -79,7 +81,7 @@ export default function ProfileImage({
       <img
         src={imageSrc}
         alt={`صورة ${user.username}`}
-        className={`${sizeClasses[size]} rounded-full ring-2 ${borderColor} shadow-sm object-cover ${className} ${gradientBorder ? 'relative' : ''}`}
+        className={`w-full h-full rounded-full ring-inset ring-2 ${borderColor} shadow-sm object-cover ${className}`}
         style={{
           transition: 'none',
           backfaceVisibility: 'hidden',

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1283,6 +1283,8 @@ li > * > div.effect-crystal {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  border-radius: 9999px;
+  overflow: hidden;
 }
 .vip-frame-inner {
   position: relative;
@@ -1305,10 +1307,11 @@ li > * > div.effect-crystal {
 .vip-frame.base::before {
   content: '';
   position: absolute;
-  inset: -2px;
+  inset: 0;
   border-radius: 9999px;
   z-index: 1;
   padding: 2px; /* frame thickness */
+  box-sizing: border-box;
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,
     linear-gradient(#000 0 0);


### PR DESCRIPTION
Fix avatar frames (static gradient and VIP spinning) overflowing their image containers by ensuring they are clipped within the image's rounded boundaries.

---
<a href="https://cursor.com/background-agent?bcId=bc-27a06baa-efaa-470a-9ce9-3de21e20ea2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-27a06baa-efaa-470a-9ce9-3de21e20ea2d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

