### PR TITLE
Fix user profile display in settings tab

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2075,27 +2075,7 @@ export default function ProfileModal({
               </>
             )}
 
-            {getProfileBannerSrcLocal() && (
-              <div className="profile-avatar">
-                {localUser ? (
-                  <ProfileImage user={localUser as any} size="large" className="w-full h-full" />
-                ) : (
-                  <img
-                    src={getProfileImageSrcLocal()}
-                    alt="الصورة الشخصية"
-                    style={{
-                      width: '100%',
-                      height: '100%',
-                      objectFit: 'cover',
-                      display: 'block',
-                      transition: 'none',
-                      backfaceVisibility: 'hidden',
-                      transform: 'translateZ(0)',
-                    }}
-                  />
-                )}
-              </div>
-            )}
+            {/* تمت إزالة أفاتار الغلاف حسب الطلب */}
 
             {localUser?.id === currentUser?.id && (
               <button


### PR DESCRIPTION
Remove the cover avatar from the profile modal to unify the profile view from user list and settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-c04e0d1d-3cdd-4587-897e-943e2818e0ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c04e0d1d-3cdd-4587-897e-943e2818e0ab">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

