### PR TITLE
Adjust user name position on profile card

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1241,7 +1241,7 @@ export default function ProfileModal({
         /* شريط الأزرار بجانب الصورة الشخصية */
         .profile-actions {
           position: absolute;
-          bottom: 45px;
+          bottom: 20px;
           left: 160px;
           right: auto;
           display: flex;
@@ -1982,7 +1982,7 @@ export default function ProfileModal({
                 {/* اسم المستخدم مع الرتبة */}
                 <div style={{
                   position: 'absolute',
-                  bottom: '60px',
+                  bottom: '40px',
                   left: '160px',
                   display: 'flex',
                   flexDirection: 'column',
@@ -2026,7 +2026,7 @@ export default function ProfileModal({
                 {/* اسم المستخدم مع الرتبة */}
                 <div style={{
                   position: 'absolute',
-                  bottom: '70px',
+                  bottom: '50px',
                   left: '160px',
                   display: 'flex',
                   flexDirection: 'column',


### PR DESCRIPTION
Adjust user name and action button positions in the profile modal.

The username was moved down slightly to be above the cover image and before its end, and the profile action buttons were repositioned to align with the new name placement.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0a1ff30-f3f2-4f68-a4c6-db61d6bbafae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c0a1ff30-f3f2-4f68-a4c6-db61d6bbafae">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

