### PR TITLE
Adjust user profile name position

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1981,7 +1981,7 @@ export default function ProfileModal({
                 {/* اسم المستخدم مع الرتبة */}
                 <div style={{
                   position: 'absolute',
-                  bottom: '60px',
+                  bottom: '45px',
                   left: '160px',
                   display: 'flex',
                   flexDirection: 'column',
@@ -2025,7 +2025,7 @@ export default function ProfileModal({
                 {/* اسم المستخدم مع الرتبة */}
                 <div style={{
                   position: 'absolute',
-                  bottom: '70px',
+                  bottom: '45px',
                   left: '160px',
                   display: 'flex',
                   flexDirection: 'column',


### PR DESCRIPTION
Adjust the vertical position of the user's name and title in the profile card to lower them slightly, closer to the cover image edge.

---
<a href="https://cursor.com/background-agent?bcId=bc-652e46d4-8e3b-4958-91ec-b34a6d23e473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-652e46d4-8e3b-4958-91ec-b34a6d23e473">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

