### PR TITLE
Align profile buttons with cover and profile picture

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1238,14 +1238,15 @@ export default function ProfileModal({
         /* شريط الأزرار على حافة صورة الغلاف السفلية */
         .profile-actions {
           position: absolute;
-          bottom: 10px;
+          bottom: 0;
           left: 170px;
-          right: 20px;
+          right: auto;
           display: flex;
-          gap: 8px;
+          gap: 10px;
           align-items: center;
-          flex-wrap: wrap;
+          flex-wrap: nowrap;
           z-index: 10;
+          padding-bottom: 12px;
         }
 
         .profile-actions button {
@@ -1936,10 +1937,13 @@ export default function ProfileModal({
           
           /* أنماط الأزرار للأجهزة المحمولة */
           .profile-actions {
-            bottom: 8px;
+            bottom: 0;
             left: 120px;
-            right: 10px;
+            right: auto;
             gap: 6px;
+            padding-bottom: 8px;
+            flex-wrap: wrap;
+            max-width: calc(100% - 140px);
           }
           
           .profile-actions button {


### PR DESCRIPTION
Reposition profile action buttons to align with the bottom of the cover image and the left of the profile picture.

---
<a href="https://cursor.com/background-agent?bcId=bc-11c6f0bb-7440-4e56-9d84-1ae09ffa07f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-11c6f0bb-7440-4e56-9d84-1ae09ffa07f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

