### PR TITLE
Rearrange chat elements to the left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1999,10 +1999,10 @@ export default function ProfileModal({
                 <div style={{
                   position: 'absolute',
                   bottom: '45px',
-                  left: '20px',
+                  left: '160px',
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: 'flex-start',
+                  alignItems: 'center',
                   gap: '2px',
                   zIndex: 3
                 }}>
@@ -2043,10 +2043,10 @@ export default function ProfileModal({
                 <div style={{
                   position: 'absolute',
                   bottom: '45px',
-                  left: '20px',
+                  left: '160px',
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: 'flex-start',
+                  alignItems: 'center',
                   gap: '2px',
                   zIndex: 3
                 }}>

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1239,7 +1239,7 @@ export default function ProfileModal({
         .profile-actions {
           position: absolute;
           bottom: 0;
-          left: 170px;
+          left: 20px;
           right: auto;
           display: flex;
           gap: 10px;
@@ -1938,7 +1938,7 @@ export default function ProfileModal({
           /* أنماط الأزرار للأجهزة المحمولة */
           .profile-actions {
             bottom: 0;
-            left: 120px;
+            left: 15px;
             right: auto;
             gap: 6px;
             padding-bottom: 8px;

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1999,10 +1999,10 @@ export default function ProfileModal({
                 <div style={{
                   position: 'absolute',
                   bottom: '45px',
-                  left: '160px',
+                  left: '20px',
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: 'center',
+                  alignItems: 'flex-start',
                   gap: '2px',
                   zIndex: 3
                 }}>
@@ -2043,10 +2043,10 @@ export default function ProfileModal({
                 <div style={{
                   position: 'absolute',
                   bottom: '45px',
-                  left: '160px',
+                  left: '20px',
                   display: 'flex',
                   flexDirection: 'column',
-                  alignItems: 'center',
+                  alignItems: 'flex-start',
                   gap: '2px',
                   zIndex: 3
                 }}>
@@ -2112,14 +2112,14 @@ export default function ProfileModal({
                 <button className="btn-chat" onClick={() => onPrivateMessage?.(localUser)}>
                   💬 محادثة خاصة
                 </button>
-                <button className="btn-add" onClick={() => onAddFriend?.(localUser)}>
-                  👥 إضافة صديق
-                </button>
                 <button className="btn-ignore" onClick={() => onIgnoreUser?.(localUser?.id || 0)}>
                   🚫 تجاهل
                 </button>
+                <button className="btn-add" onClick={() => onAddFriend?.(localUser)}>
+                  👥 إضافة صديق
+                </button>
                 <button className="btn-report" onClick={() => onReportUser?.(localUser)}>
-                  🚩 إبلاغ
+                  🚩 بلاغ
                 </button>
               </div>
             )}


### PR DESCRIPTION
Reposition profile action buttons and username to the left and reorder buttons to prevent overlap with the profile picture.

The user explicitly requested these buttons (private chat, ignore, add friend, report) to be moved to the far left, in a specific order, and to not overlap with the profile picture area. This PR implements those layout and ordering changes, including mobile responsiveness.

---
<a href="https://cursor.com/background-agent?bcId=bc-679faa16-30fe-4420-b006-9a223c248c00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-679faa16-30fe-4420-b006-9a223c248c00">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

