### PR TITLE
Move profile action buttons to the left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1239,7 +1239,7 @@ export default function ProfileModal({
         .profile-actions {
           position: absolute;
           bottom: 15px;
-          left: 160px;
+          left: 16px;
           right: auto;
           display: flex;
           gap: 5px;
@@ -1938,7 +1938,7 @@ export default function ProfileModal({
           /* أنماط الأزرار للأجهزة المحمولة */
           .profile-actions {
             bottom: 10px;
-            left: 120px;
+            left: 16px;
             right: auto;
             gap: 3px;
             padding: 0;


### PR DESCRIPTION
Move profile action buttons to the far left to prevent overlapping the profile picture.

---
<a href="https://cursor.com/background-agent?bcId=bc-2493920c-b097-4247-9431-2535b6962a93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2493920c-b097-4247-9431-2535b6962a93">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

