### PR TITLE
Align control buttons left of profile picture

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1239,7 +1239,7 @@ export default function ProfileModal({
         .profile-actions {
           position: absolute;
           bottom: 15px;
-          left: 160px;
+          left: 20px;
           right: auto;
           display: flex;
           gap: 5px;
@@ -1938,7 +1938,7 @@ export default function ProfileModal({
           /* أنماط الأزرار للأجهزة المحمولة */
           .profile-actions {
             bottom: 10px;
-            left: 120px;
+            left: 10px;
             right: auto;
             gap: 3px;
             padding: 0;


### PR DESCRIPTION
Move profile action buttons further left to prevent overlap with the profile picture.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8db4200-3009-49bf-b73f-1a47cd2ed3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8db4200-3009-49bf-b73f-1a47cd2ed3ee">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

