### PR TITLE
Fix user profile display consistency

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -346,6 +346,13 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     });
   };
 
+  // دالة موحدة لفتح ProfileModal مباشرة
+  const handleDirectProfileOpen = (user: ChatUser) => {
+    setProfileUser(user);
+    setShowProfile(true);
+    closeUserPopup();
+  };
+
   const closeUserPopup = () => {
     setUserPopup((prev) => ({ ...prev, show: false }));
   };
@@ -1161,6 +1168,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         <Suspense fallback={null}>
           <SettingsMenu
             onOpenProfile={() => {
+              setProfileUser(chat.currentUser);
               setShowProfile(true);
               setShowSettings(false);
             }}
@@ -1373,7 +1381,10 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           isOpen={showRichest}
           onClose={() => setShowRichest(false)}
           currentUser={chat.currentUser}
-          onUserClick={handleUserClick}
+          onUserClick={(e, user) => {
+            e.stopPropagation();
+            handleDirectProfileOpen(user);
+          }}
         />
       </Suspense>
 


### PR DESCRIPTION
Unify profile display by ensuring `ProfileModal` opens correctly from Settings and Richest tab.

Previously, opening the profile from Settings didn't set the `profileUser`, leading to an incomplete display. From the Richest tab, it incorrectly opened a `UserPopup` instead of the full `ProfileModal`. This PR fixes these inconsistencies to provide a uniform user profile experience across all sections.

---
<a href="https://cursor.com/background-agent?bcId=bc-0a83dcf0-c4b1-4a29-b17d-7185308cd9ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0a83dcf0-c4b1-4a29-b17d-7185308cd9ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

