### PR TITLE
Fix profile display bug in settings tab

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1161,8 +1161,27 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         <Suspense fallback={null}>
           <SettingsMenu
             onOpenProfile={() => {
+              // افتح فوراً ببيانات المستخدم الحالية لسرعة الاستجابة
+              if (chat.currentUser) {
+                setProfileUser(chat.currentUser);
+              }
               setShowProfile(true);
               setShowSettings(false);
+
+              // ثم اجلب نسخة محدثة وكاملة لتوحيد العرض مع قائمة المستخدمين
+              try {
+                const userId = chat.currentUser?.id;
+                if (userId) {
+                  (async () => {
+                    try {
+                      const data = await apiRequest(`/api/users/${userId}?t=${Date.now()}`);
+                      if (data && (data as any).id) {
+                        setProfileUser(data as any);
+                      }
+                    } catch {}
+                  })();
+                }
+              } catch {}
             }}
             onLogout={onLogout}
             onClose={() => setShowSettings(false)}


### PR DESCRIPTION
Ensure the profile modal displays completely when opened from the settings tab, matching the view from the users list.

The original implementation for opening the profile from settings did not fully populate the `profileUser` state or fetch a complete user object, leading to an incomplete display. This change first sets the current user for quick display and then fetches a full, updated user profile to ensure all details are present, aligning with the behavior of opening a profile from the users list.

---
<a href="https://cursor.com/background-agent?bcId=bc-9369d61b-7b4b-4474-b085-d917bc03ff24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9369d61b-7b4b-4474-b085-d917bc03ff24">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

