### PR TITLE
Deploy project with database relation error

### DIFF
--- a/migrations/0010_add_story_reactions.sql
+++ b/migrations/0010_add_story_reactions.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS story_reactions (
+  id SERIAL PRIMARY KEY,
+  story_id INTEGER NOT NULL REFERENCES stories(id) ON DELETE CASCADE,
+  user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  reacted_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_story_reactions_story ON story_reactions (story_id);
+CREATE INDEX IF NOT EXISTS idx_story_reactions_user ON story_reactions (user_id);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_story_reactions_unique ON story_reactions (story_id, user_id);


### PR DESCRIPTION
Add `story_reactions` table migration and a runtime safeguard to resolve "relation does not exist" errors.

The application was failing to query the `story_reactions` table because it was missing from the database. This PR introduces a new migration file to formally create the table and its indexes, and also adds a runtime check in `ensureStoriesTables` to automatically create the table if it's not found, preventing future deployment issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d58dfbf-85a0-4c83-913d-a38d6b9d2983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d58dfbf-85a0-4c83-913d-a38d6b9d2983">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

