### PR TITLE
Changes from background agent bc-fe90e630-47a7-4a47-b708-f35c4d06df74

### DIFF
--- a/server/database-setup.ts
+++ b/server/database-setup.ts
@@ -18,6 +18,7 @@ import {
   runMigrationsIfAvailable,
 } from './database-adapter';
 import { ensureStoriesTables } from './database-adapter';
+import { ensureUserProfileMusicColumns } from './database-adapter';
 
 // إعادة تصدير دالة التهيئة من المحول
 export { initializeDatabase } from './database-adapter';
@@ -252,6 +253,13 @@ export async function initializeSystem(): Promise<boolean> {
       await ensureStoriesTables();
     } catch (e) {
       console.warn('⚠️ تعذر ضمان جداول القصص:', (e as any)?.message || e);
+    }
+
+    // ضمان أعمدة موسيقى البروفايل في حال لم تُطبق الهجرات
+    try {
+      await ensureUserProfileMusicColumns();
+    } catch (e) {
+      console.warn('⚠️ تعذر ضمان أعمدة موسيقى البروفايل:', (e as any)?.message || e);
     }
 
     // إنشاء الغرف الافتراضية إذا كانت غير موجودة (بعد الهجرات)


### PR DESCRIPTION
Add a fallback migration path and ensure profile music columns exist to fix "column does not exist" errors.

The application was failing with `PostgresError: column "profile_music_url" does not exist` because the production database schema was missing expected columns from the `users` table. This PR updates the Drizzle migrator to also check the `dist/migrations` folder (where Render copies them) and adds a safety net function to explicitly create these columns during system initialization if migrations fail to apply them.

---
<a href="https://cursor.com/background-agent?bcId=bc-fe90e630-47a7-4a47-b708-f35c4d06df74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fe90e630-47a7-4a47-b708-f35c4d06df74">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

