### PR TITLE
Prevent direct audio link input

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -804,7 +804,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         'profileImage',
         'profileBanner',
         // موسيقى البروفايل
-        'profileMusicUrl',
+        // ملاحظة: يمنع تحديث profileMusicUrl يدوياً — يجب الرفع عبر /api/upload/profile-music
         'profileMusicTitle',
         'profileMusicEnabled',
         'profileMusicVolume',
@@ -815,6 +815,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         if (Object.prototype.hasOwnProperty.call(req.body, key)) {
           updateData[key] = (req.body as any)[key];
         }
+      }
+
+      // منع تحديث رابط الموسيقى يدوياً عبر هذا المسار
+      if (Object.prototype.hasOwnProperty.call(req.body, 'profileMusicUrl')) {
+        return res.status(400).json({ error: 'غير مسموح بتحديث رابط الموسيقى يدوياً. استخدم رفع الملف.' });
       }
 
       if (Object.keys(updateData).length === 0) {
@@ -3054,11 +3059,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // دعم حقول موسيقى البروفايل
+      // يمنع تعديل رابط الموسيقى يدوياً — يجب الرفع عبر /api/upload/profile-music
       if (updates.profileMusicUrl !== undefined) {
-        if (typeof updates.profileMusicUrl !== 'string' || updates.profileMusicUrl.length > 1000) {
-          return res.status(400).json({ error: 'رابط الموسيقى غير صالح' });
-        }
-        validatedUpdates.profileMusicUrl = updates.profileMusicUrl.trim();
+        return res.status(400).json({ error: 'غير مسموح بتحديث رابط الموسيقى يدوياً. استخدم رفع الملف.' });
       }
       if (updates.profileMusicTitle !== undefined) {
         if (typeof updates.profileMusicTitle !== 'string' || updates.profileMusicTitle.length > 200) {

--- a/server/utils/data-sanitizer.ts
+++ b/server/utils/data-sanitizer.ts
@@ -113,13 +113,18 @@ export function sanitizeTheme(theme: string | null | undefined): string {
 export function sanitizeUserData(user: any): any {
   if (!user) return user;
 
+  const safeMusicUrl =
+    typeof user.profileMusicUrl === 'string' && user.profileMusicUrl.startsWith('/uploads/music/')
+      ? user.profileMusicUrl
+      : undefined;
+
   return {
     ...user,
     profileBackgroundColor: sanitizeProfileBackgroundColor(user.profileBackgroundColor),
     usernameColor: sanitizeHexColor(user.usernameColor, '#000000'),
     profileEffect: sanitizeEffect(user.profileEffect),
     // موسيقى البروفايل
-    profileMusicUrl: typeof user.profileMusicUrl === 'string' ? user.profileMusicUrl : undefined,
+    profileMusicUrl: safeMusicUrl,
     profileMusicTitle: typeof user.profileMusicTitle === 'string' ? user.profileMusicTitle : undefined,
     profileMusicEnabled:
       typeof user.profileMusicEnabled === 'boolean' ? user.profileMusicEnabled : true,


### PR DESCRIPTION
Enforce file uploads for profile music by preventing manual `profileMusicUrl` updates and sanitizing existing URLs to only expose system-uploaded files.

The user requested to disallow manual URL inputs for profile music, preferring that users upload audio files directly to ensure content control and system integrity. This PR implements that by blocking direct `profileMusicUrl` updates in API routes and ensuring only server-uploaded paths are exposed in user data.

---
<a href="https://cursor.com/background-agent?bcId=bc-a2547c86-b959-42db-a0b3-b7d2c157b144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a2547c86-b959-42db-a0b3-b7d2c157b144">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

