### PR TITLE
Remove music bar from other profiles

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2056,7 +2056,7 @@ export default function ProfileModal({
             }}
           >
             {/* مشغل الموسيقى - يظهر أعلى يمين الغلاف */}
-            {localUser?.profileMusicUrl && musicEnabled && (
+            {localUser?.profileMusicUrl && musicEnabled && localUser?.id === currentUser?.id && (
               <div
                 style={{
                   position: 'absolute',


### PR DESCRIPTION
Hide the profile music player when viewing another user's profile.

The music player should only be visible when a user is viewing their own profile, not when viewing other users' profiles.

---
<a href="https://cursor.com/background-agent?bcId=bc-e5fd7664-dd9f-40d8-90ff-d887af6f6e16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e5fd7664-dd9f-40d8-90ff-d887af6f6e16">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

