### PR TITLE
Remove default colored box for visitors and members

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -506,7 +506,7 @@ export default function UnifiedSidebar({
               showModerationActions={isModerator}
             >
               <div
-                className={`flex items-center gap-2 py-1.5 px-0 rounded-none border-b border-black transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user) || 'bg-card hover:bg-accent/10'}`}
+                className={`flex items-center gap-2 py-1.5 px-0 rounded-none border-b border-black transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
                 style={getUserListItemStyles(user)}
                 onClick={(e) => handleUserClick(e as any, user)}
               >

--- a/client/src/utils/themeUtils.ts
+++ b/client/src/utils/themeUtils.ts
@@ -195,7 +195,14 @@ export const getUserEffectStyles = (user: any): Record<string, string> => {
 
 // دالة موحدة للحصول على أنماط عنصر المستخدم في القائمة
 export const getUserListItemStyles = (user: any): Record<string, string> => {
-  // استخدام نفس المنطق المستخدم في الملف الشخصي
+  // فقط المشرفين والإدمن والمالك يحصلون على تأثيرات خاصة
+  // الزوار والأعضاء العاديين بدون لون خلفية
+  if (user?.userType === 'guest' || user?.userType === 'member') {
+    // إرجاع كائن فارغ للزوار والأعضاء (بدون ألوان خلفية)
+    return {};
+  }
+  
+  // استخدام نفس المنطق المستخدم في الملف الشخصي للمشرفين فقط
   return getUserEffectStyles(user);
 };
 
@@ -203,12 +210,18 @@ export const getUserListItemStyles = (user: any): Record<string, string> => {
 export const getUserListItemClasses = (user: any): string => {
   const classes = [] as string[];
 
-  // إضافة كلاس التأثير إذا وجد
+  // فقط المشرفين والإدمن والمالك يحصلون على كلاسات التأثيرات
+  if (user?.userType === 'guest' || user?.userType === 'member') {
+    // إرجاع كلاس فارغ للزوار والأعضاء
+    return '';
+  }
+
+  // إضافة كلاس التأثير إذا وجد (للمشرفين فقط)
   if (user?.profileEffect && user.profileEffect !== 'none') {
     classes.push(user.profileEffect);
   }
 
-  // إضافة كلاس خاص إذا كان هناك لون خلفية
+  // إضافة كلاس خاص إذا كان هناك لون خلفية (للمشرفين فقط)
   if (user?.profileBackgroundColor && user.profileBackgroundColor !== 'null' && user.profileBackgroundColor !== 'undefined') {
     classes.push('has-custom-bg');
   }


### PR DESCRIPTION
Remove the default brown background from guest and member user list items to make them appear without a background color.

---
<a href="https://cursor.com/background-agent?bcId=bc-eb52cdd5-ffe9-4e54-a610-893ed2734ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-eb52cdd5-ffe9-4e54-a610-893ed2734ede">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

