### PR TITLE
Redesign bottom navigation with svg icons

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -9,8 +9,6 @@ import {
   X,
   Users,
   Globe,
-  Home,
-  UserPlus,
 } from 'lucide-react';
 import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { Virtuoso } from 'react-virtuoso';
@@ -543,49 +541,7 @@ export default function UnifiedSidebar({
     <aside
       className={`w-full bg-card text-sm overflow-hidden border-l border-border shadow-lg flex flex-col h-full max-h-screen ${isMobile ? 'sidebar mobile-scroll' : ''}`}
     >
-      {/* Toggle Buttons - always visible now */}
-      <div className={`flex border-b border-gray-200 flex-shrink-0 ${isMobile ? 'flex-wrap' : ''}`}>
-        <Button
-          variant={activeView === 'users' ? 'default' : 'ghost'}
-          className={`flex-1 rounded-none ${isMobile ? 'py-2 px-2 text-xs' : 'py-3'} ${
-            activeView === 'users' ? 'bg-blue-500 text-white' : 'text-gray-600 hover:bg-gray-100'
-          } ${isMobile ? 'mobile-touch-button' : ''}`}
-          onClick={() => setActiveView('users')}
-        >
-          <Users className="w-4 h-4 ml-2" />
-          المستخدمون
-        </Button>
-        <Button
-          variant={activeView === 'walls' ? 'default' : 'ghost'}
-          className={`flex-1 rounded-none ${isMobile ? 'py-2 px-2 text-xs' : 'py-3'} ${
-            activeView === 'walls' ? 'bg-blue-500 text-white' : 'text-gray-600 hover:bg-gray-100'
-          } ${isMobile ? 'mobile-touch-button' : ''}`}
-          onClick={() => setActiveView('walls')}
-        >
-          <Home className="w-4 h-4 ml-2" />
-          الحوائط
-        </Button>
-        <Button
-          variant={activeView === 'rooms' ? 'default' : 'ghost'}
-          className={`flex-1 rounded-none ${isMobile ? 'py-2 px-2 text-xs' : 'py-3'} ${
-            activeView === 'rooms' ? 'bg-blue-500 text-white' : 'text-gray-600 hover:bg-gray-100'
-          } ${isMobile ? 'mobile-touch-button' : ''}`}
-          onClick={() => setActiveView('rooms')}
-        >
-          <Users className="w-4 h-4 ml-2" />
-          الغرف
-        </Button>
-        <Button
-          variant={activeView === 'friends' ? 'default' : 'ghost'}
-          className={`flex-1 rounded-none ${isMobile ? 'py-2 px-2 text-xs' : 'py-3'} ${
-            activeView === 'friends' ? 'bg-blue-500 text-white' : 'text-gray-600 hover:bg-gray-100'
-          } ${isMobile ? 'mobile-touch-button' : ''}`}
-          onClick={() => setActiveView('friends')}
-        >
-          <UserPlus className="w-4 h-4 ml-2" />
-          الأصدقاء
-        </Button>
-      </div>
+      {/* Top toggle buttons removed; bottom bar is the sole navigation */}
 
       {/* Users View - تحسين التمرير */}
       {activeView === 'users' && (


### PR DESCRIPTION
Remove duplicate top navigation tabs to ensure only the bottom bar serves as the primary navigation.

---
<a href="https://cursor.com/background-agent?bcId=bc-4e0bb50f-f9b3-418f-b619-dafc380ad1a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4e0bb50f-f9b3-418f-b619-dafc380ad1a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

