### PR TITLE
Remove outer border and expand chat room selection

### DIFF
--- a/client/src/components/chat/RoomSelectorScreen.tsx
+++ b/client/src/components/chat/RoomSelectorScreen.tsx
@@ -73,20 +73,20 @@ export default function RoomSelectorScreen({ currentUser, onSelectRoom }: RoomSe
 	}, [rooms, loading, currentUser, fetchRooms]);
 
 	return (
-		<div className="min-h-[100dvh] flex items-center justify-center p-4 relative overflow-hidden">
+		<div className="min-h-[100dvh] relative overflow-hidden">
 			{/* Modern Background Effects */}
 			<div className="absolute inset-0 overflow-hidden pointer-events-none">
 				<div className="absolute -top-1/4 -left-1/4 w-1/2 h-1/2 bg-gradient-radial from-cyan-500/10 to-transparent rounded-full blur-3xl animate-pulse"></div>
 				<div className="absolute -bottom-1/4 -right-1/4 w-1/2 h-1/2 bg-gradient-radial from-purple-500/10 to-transparent rounded-full blur-3xl animate-pulse" style={{ animationDelay: '3s' }}></div>
 			</div>
 			
-			<div className="w-full max-w-5xl relative z-10">
-				<div className="text-center mb-8 animate-fade-in">
+			<div className="h-full relative z-10 flex flex-col">
+				<div className="text-center py-8 animate-fade-in">
 					<h1 className="text-4xl font-bold gradient-text mb-3">اختر غرفة للدردشة</h1>
 					<p className="text-xl text-muted-foreground">انضم إلى إحدى الغرف المتاحة وابدأ المحادثة</p>
 				</div>
 				
-				<div className="modern-card glass-effect p-6 animate-slide-up">
+				<div className="flex-1 px-4 pb-4 animate-slide-up">
 					{content}
 					{error && (
 						<div className="modern-notification bg-red-500/10 border-red-500/20 text-red-400 mt-4 text-center">


### PR DESCRIPTION
Expand the room selection content to fill the screen by removing its outer frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-bcb0f8be-43f5-4ce4-bd39-1bdfa38b874c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bcb0f8be-43f5-4ce4-bd39-1bdfa38b874c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

