### PR TITLE
Fix user name color bug in messages and friends

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -395,7 +395,7 @@ export default function FriendsTabPanel({
                       showModerationActions={isModerator}
                     >
                       <div
-                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-gray-200 transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(friend) || 'bg-white hover:bg-gray-50'}`}
+                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-gray-200 transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(friend) || 'hover:bg-gray-50'}`}
                         style={getUserListItemStyles(friend)}
                         onClick={(e) => onStartPrivateChat(friend)}
                       >

--- a/client/src/components/chat/MessagesPanel.tsx
+++ b/client/src/components/chat/MessagesPanel.tsx
@@ -346,7 +346,7 @@ export default function MessagesPanel({
                   {conversations.map(({ user, lastMessage, unreadCount }) => (
                     <div key={user.id} className="relative -mx-4">
                       <div
-                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-gray-200 transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(user) || 'bg-white hover:bg-gray-50'}`}
+                        className={`flex items-center gap-2 p-2 px-4 rounded-none border-b border-gray-200 transition-all duration-200 cursor-pointer w-full ${getUserListItemClasses(user) || 'hover:bg-gray-50'}`}
                         style={getUserListItemStyles(user)}
                         onClick={() => {
                           try {


### PR DESCRIPTION
Remove default white background for regular users in Friends and Messages panels to ensure consistent styling.

Previously, regular users (guests and members) appeared with a white background in the Friends and Messages lists, while in the main user list, they correctly had no background color. This change aligns the styling across all user list displays.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fceab43-6389-4b55-ac27-d4b266a31110">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fceab43-6389-4b55-ac27-d4b266a31110">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

