### PR TITLE
Fix and perfect room locking system

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -714,7 +714,9 @@ export const useChat = () => {
           case 'roomJoined': {
             const roomId = (envelope as any).roomId;
             if (roomId && roomId !== currentRoomIdRef.current) {
-              break;
+              // Switch local state to the confirmed room and persist session
+              dispatch({ type: 'SET_CURRENT_ROOM', payload: roomId });
+              try { saveSession({ roomId }); } catch {}
             }
             // استبدال القائمة بالكامل بقائمة الغرفة المرسلة (مع فلترة وإزالة التكرارات)
             const users = (envelope as any).users;
@@ -1319,9 +1321,7 @@ export const useChat = () => {
         return;
       }
 
-      dispatch({ type: 'SET_CURRENT_ROOM', payload: roomId });
-      saveSession({ roomId });
-
+      // Do NOT change local room yet; wait for server ack (roomJoined)
       if (socket.current?.connected && state.currentUser?.id) {
         socket.current.emit('joinRoom', {
           roomId,


### PR DESCRIPTION
Prevent unauthorized room entry and message sending by making client room changes server-confirmed and adding server-side room membership validation for messages.

Previously, the client optimistically updated `currentRoomId` before server confirmation, allowing users to appear in locked rooms despite server-side join restrictions. Additionally, the server did not fully validate if a user was a member of a room before allowing them to send messages to it, creating a bypass for locked rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-7cf19f48-1d6b-4cae-a7ce-34547ca5554d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7cf19f48-1d6b-4cae-a7ce-34547ca5554d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

