### PR TITLE
Handle locked room join error

### DIFF
--- a/migrations/0012_add_room_is_locked.sql
+++ b/migrations/0012_add_room_is_locked.sql
@@ -1,0 +1,5 @@
+-- Add is_locked column to rooms table
+ALTER TABLE "rooms" ADD COLUMN IF NOT EXISTS "is_locked" boolean DEFAULT false;
+
+-- Update existing rooms to have is_locked as false
+UPDATE "rooms" SET "is_locked" = false WHERE "is_locked" IS NULL;

--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -93,6 +93,7 @@ export interface Room {
   isDefault?: boolean;
   isActive?: boolean;
   isBroadcast?: boolean;
+  isLocked?: boolean;
   hostId?: number | null;
   speakers?: string | any[];
   micQueue?: string | any[];

--- a/server/services/roomService.ts
+++ b/server/services/roomService.ts
@@ -239,7 +239,9 @@ class RoomService {
       }
 
       // منع الانضمام إن كانت الغرفة مقفلة (ما عدا المشرفين والإداريين والمالكين)
-      if ((room as any).isLocked === true) {
+      // Check if room is locked (default to false if undefined)
+      const isRoomLocked = room.isLocked ?? false;
+      if (isRoomLocked === true) {
         const isPrivileged = ['admin', 'owner', 'moderator'].includes(user.userType);
         if (!isPrivileged) {
           throw new Error('الغرفة مقفلة ولا يمكن الدخول إليها');

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -895,6 +895,7 @@ export const storage: LegacyStorage = {
           description: 'الغرفة العامة للدردشة',
           isDefault: true,
           isActive: true,
+          isLocked: false,
           isBroadcast: false,
           hostId: null,
           speakers: '[]',


### PR DESCRIPTION
Fix 'room is locked' error by properly defining and handling the `isLocked` field across the application and adding a database migration.

The error occurred because the `isLocked` field was missing from the database `Room` interface, leading to unsafe type casting (`(room as any).isLocked`) and potential runtime failures. This PR ensures the field is correctly typed, safely accessed with a default value, and present in the database with a migration for existing rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-23f8f2ee-d665-49bc-a9de-85240454c632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-23f8f2ee-d665-49bc-a9de-85240454c632">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

