### PR TITLE
Fix overlapping room names for admins

### DIFF
--- a/client/src/components/chat/RoomComponent.tsx
+++ b/client/src/components/chat/RoomComponent.tsx
@@ -97,12 +97,12 @@ const RoomCard: React.FC<RoomCardProps> = ({
     
     return (
       <div className="flex-1 min-w-0">
-        <div
-          className={`font-medium ${compact ? 'text-sm' : 'text-base'} truncate flex items-center gap-2`}
-        >
-          {room.name}
-          {room.isBroadcast && <Mic className="w-3 h-3 text-orange-500" />}
-          {room.isLocked && <Lock className="w-3 h-3 text-yellow-600" />}
+        <div className={`font-medium ${compact ? 'text-sm' : 'text-base'} flex items-center gap-2 min-w-0`}>
+          <span className="truncate">{room.name}</span>
+          <span className="flex items-center gap-1 flex-shrink-0">
+            {room.isBroadcast && <Mic className="w-3 h-3 text-orange-500" />}
+            {room.isLocked && <Lock className="w-3 h-3 text-yellow-600" />}
+          </span>
           {/* إزالة شارة "افتراضي" بناءً على طلب العميل */}
         </div>
         <div className={`${compact ? 'text-xs' : 'text-sm'} text-muted-foreground`}>
@@ -130,7 +130,7 @@ const RoomCard: React.FC<RoomCardProps> = ({
         <RoomInfo />
 
         {(canModerate || canDelete) && (
-          <div className="flex items-center gap-1">
+          <div className="ml-auto flex items-center gap-1 flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none group-hover:pointer-events-auto">
             {canModerate && onToggleLock && (
               <Button
                 onClick={(e) => {


### PR DESCRIPTION
Adjust room list item layout to prevent name and icon overlap for moderators and refine moderator action button behavior.

---
<a href="https://cursor.com/background-agent?bcId=bc-604f9f0f-36ff-42f7-ba96-e5d5a8a8f050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-604f9f0f-36ff-42f7-ba96-e5d5a8a8f050">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

