### PR TITLE
Fix non-functional privacy and terms tabs

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -761,19 +761,13 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         {/* روابط سياسة الخصوصية وشروط الاستخدام (يمين الشريط)، والشعار مثبت يساراً */}
         <div className="flex items-center gap-4 flex-shrink-0">
           <div className="hidden sm:flex items-center gap-3 text-sm">
-            <button
-              onClick={() => setLocation('/privacy')}
-              className="text-gray-300 hover:text-white hover:underline"
-            >
+            <a href="/privacy" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               سياسة الخصوصية
-            </button>
-            <span className="text-gray-500">|</span>
-            <button
-              onClick={() => setLocation('/terms')}
-              className="text-gray-300 hover:text-white hover:underline"
-            >
+            </a>
+            <span className="text-gray-400">|</span>
+            <a href="/terms" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               شروط الاستخدام
-            </button>
+            </a>
           </div>
           <div
             className={`flex items-center gap-2 cursor-pointer select-none ${isMobile ? 'self-start' : ''}`}

--- a/client/src/components/chat/CountryWelcomeScreen.tsx
+++ b/client/src/components/chat/CountryWelcomeScreen.tsx
@@ -215,13 +215,13 @@ export default function CountryWelcomeScreen({ onUserLogin, countryData }: Count
         <div className="max-w-6xl mx-auto flex justify-between items-center">
           {/* روابط الشريط العلوي */}
           <div className="flex items-center gap-3 text-sm">
-            <button onClick={() => setLocation('/privacy')} className="text-gray-300 hover:text-white hover:underline">
+            <a href="/privacy" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               سياسة الخصوصية
-            </button>
-            <span className="text-gray-500">|</span>
-            <button onClick={() => setLocation('/terms')} className="text-gray-300 hover:text-white hover:underline">
+            </a>
+            <span className="text-gray-400">|</span>
+            <a href="/terms" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               شروط الاستخدام
-            </button>
+            </a>
           </div>
           {/* الشعار المثبت يساراً: أبيض وأزرق */}
           <div className="flex items-center gap-2 cursor-default select-none">

--- a/client/src/components/chat/WelcomeScreen.tsx
+++ b/client/src/components/chat/WelcomeScreen.tsx
@@ -1,5 +1,4 @@
 import { UserPlus, MessageCircle } from 'lucide-react';
-import { useLocation } from 'wouter';
 import { useState } from 'react';
 
 import UserRegistration from './UserRegistration';
@@ -17,7 +16,6 @@ interface WelcomeScreenProps {
 }
 
 export default function WelcomeScreen({ onUserLogin }: WelcomeScreenProps) {
-  const [, setLocation] = useLocation();
   const [showGuestModal, setShowGuestModal] = useState(false);
   const [showMemberModal, setShowMemberModal] = useState(false);
   const [showRegisterModal, setShowRegisterModal] = useState(false);
@@ -184,19 +182,13 @@ export default function WelcomeScreen({ onUserLogin }: WelcomeScreenProps) {
         <div className="max-w-6xl mx-auto flex justify-between items-center">
           {/* روابط الشريط العلوي: سياسة الخصوصية | شروط الاستخدام (توضع يميناً في RTL) */}
           <div className="flex items-center gap-3 text-sm">
-            <button
-              onClick={() => setLocation('/privacy')}
-              className="text-gray-300 hover:text-white hover:underline"
-            >
+            <a href="/privacy" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               سياسة الخصوصية
-            </button>
-            <span className="text-gray-500">|</span>
-            <button
-              onClick={() => setLocation('/terms')}
-              className="text-gray-300 hover:text-white hover:underline"
-            >
+            </a>
+            <span className="text-gray-400">|</span>
+            <a href="/terms" className="text-blue-400 hover:text-blue-300 transition-colors underline">
               شروط الاستخدام
-            </button>
+            </a>
           </div>
 
           {/* الشعار المثبت يساراً: أبيض وأزرق */}


### PR DESCRIPTION
Convert non-functional white 'Privacy Policy' and 'Terms of Use' buttons to standard anchor links (`<a>`) to ensure consistent and working navigation across the application.

The previous implementation used `onClick` handlers with `setLocation` from `wouter`, which was not correctly navigating for these specific white buttons. Switching to standard `<a>` tags provides reliable navigation, matching the behavior of the existing blue links.

---
<a href="https://cursor.com/background-agent?bcId=bc-d42876d8-449e-474d-9bd4-e04e260ecb98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d42876d8-449e-474d-9bd4-e04e260ecb98">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

