### PR TITLE
Enable member image uploads and admin-like profile display

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2337,7 +2337,11 @@ export default function ProfileModal({
                 <p>
                   ⭐ مستوى العضو: <span>مستوى {localUser?.level || 1}</span>
                 </p>
-                {currentUser && currentUser.userType !== 'guest' && (
+                {currentUser && (
+                  currentUser.userType === 'owner' || 
+                  currentUser.userType === 'admin' || 
+                  currentUser.userType === 'moderator'
+                ) && (
                   <>
                     <p onClick={() => setCurrentEditType('theme')} style={{ cursor: 'pointer' }}>
                       🎨 لون الملف الشخصي: <span>اضغط للتغيير</span>
@@ -2347,7 +2351,11 @@ export default function ProfileModal({
                     </p>
                   </>
                 )}
-                {currentUser && currentUser.userType !== 'guest' && (
+                {currentUser && (
+                  currentUser.userType === 'owner' || 
+                  currentUser.userType === 'admin' || 
+                  currentUser.userType === 'moderator'
+                ) && (
                   <div
                     style={{
                       marginTop: '8px',

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2239,11 +2239,7 @@ export default function ProfileModal({
             </div>
 
             {localUser?.id === currentUser?.id && 
-             currentUser && (
-               currentUser.userType === 'owner' || 
-               currentUser.userType === 'admin' || 
-               currentUser.userType === 'moderator'
-             ) && (
+             currentUser && currentUser.userType !== 'guest' && (
               <button
                 className="change-avatar-btn"
                 onClick={() => avatarInputRef.current?.click()}
@@ -2341,11 +2337,7 @@ export default function ProfileModal({
                 <p>
                   ⭐ مستوى العضو: <span>مستوى {localUser?.level || 1}</span>
                 </p>
-                {currentUser && (
-                  currentUser.userType === 'owner' || 
-                  currentUser.userType === 'admin' || 
-                  currentUser.userType === 'moderator'
-                ) && (
+                {currentUser && currentUser.userType !== 'guest' && (
                   <>
                     <p onClick={() => setCurrentEditType('theme')} style={{ cursor: 'pointer' }}>
                       🎨 لون الملف الشخصي: <span>اضغط للتغيير</span>
@@ -2355,11 +2347,7 @@ export default function ProfileModal({
                     </p>
                   </>
                 )}
-                {currentUser && (
-                  currentUser.userType === 'owner' || 
-                  currentUser.userType === 'admin' || 
-                  currentUser.userType === 'moderator'
-                ) && (
+                {currentUser && currentUser.userType !== 'guest' && (
                   <div
                     style={{
                       marginTop: '8px',

--- a/client/src/components/profile/ProfileImageUpload.tsx
+++ b/client/src/components/profile/ProfileImageUpload.tsx
@@ -49,11 +49,11 @@ export default function ProfileImageUpload({
       return;
     }
 
-    // التحقق من الصلاحيات - فقط المشرفين يمكنهم رفع الصور
-    if (currentUser.userType !== 'owner' && currentUser.userType !== 'admin' && currentUser.userType !== 'moderator') {
+    // التحقق من الصلاحيات - الأعضاء والمشرفين يمكنهم رفع الصور، الزوار لا يمكنهم
+    if (currentUser.userType === 'guest') {
       toast({
         title: 'غير مسموح',
-        description: 'هذه الميزة متاحة للمشرفين فقط',
+        description: 'هذه الميزة غير متاحة للزوار',
         variant: 'destructive',
       });
       return;
@@ -156,16 +156,12 @@ export default function ProfileImageUpload({
   };
 
   // التحقق من الصلاحيات قبل عرض المكون
-  const isAuthorized = currentUser && (
-    currentUser.userType === 'owner' || 
-    currentUser.userType === 'admin' || 
-    currentUser.userType === 'moderator'
-  );
+  const isAuthorized = currentUser && currentUser.userType !== 'guest';
 
   if (!isAuthorized) {
     return (
       <div className="text-center p-4 text-muted-foreground">
-        <p>هذه الميزة متاحة للمشرفين فقط</p>
+        <p>هذه الميزة غير متاحة للزوار</p>
       </div>
     );
   }

--- a/client/src/components/ui/StoriesSettings.tsx
+++ b/client/src/components/ui/StoriesSettings.tsx
@@ -20,12 +20,8 @@ export default function StoriesSettings({ isOpen, onClose, currentUser }: Storie
   const { toast } = useToast();
   const { myStories, fetchMine } = useStories({ autoRefresh: false });
 
-  // التحقق من الصلاحيات
-  const isAuthorized = currentUser && (
-    currentUser.userType === 'owner' || 
-    currentUser.userType === 'admin' || 
-    currentUser.userType === 'moderator'
-  );
+  // التحقق من الصلاحيات - الأعضاء والمشرفين يمكنهم رفع الحالات
+  const isAuthorized = currentUser && currentUser.userType !== 'guest';
 
   const [activeTab, setActiveTab] = useState<'add' | 'mine'>('add');
   const [caption, setCaption] = useState('');
@@ -43,7 +39,7 @@ export default function StoriesSettings({ isOpen, onClose, currentUser }: Storie
       if (!isAuthorized) {
         toast({
           title: 'غير مسموح',
-          description: 'هذه الميزة متاحة للمشرفين فقط',
+          description: 'هذه الميزة غير متاحة للزوار',
           variant: 'destructive',
         });
         return;

--- a/client/src/utils/themeUtils.ts
+++ b/client/src/utils/themeUtils.ts
@@ -131,11 +131,32 @@ const gradientToTransparent = (gradient: string, opacity: number): string => {
   return newGradient;
 };
 
-// دالة لحصول على لون الاسم النهائي (يعتمد فقط على usernameColor)
+// دالة لحصول على لون الاسم النهائي (يعتمد على usernameColor ونوع المستخدم)
 export const getFinalUsernameColor = (user: any): string => {
+  // إذا كان للمستخدم لون مخصص، استخدمه
   const color = user && user.usernameColor ? String(user.usernameColor) : '';
   const cleaned = sanitizeHexColor(color, '');
-  return cleaned || '#000000';
+  if (cleaned) return cleaned;
+  
+  // إذا لم يكن له لون مخصص، استخدم لون حسب نوع المستخدم
+  if (user && user.userType) {
+    switch (user.userType) {
+      case 'owner':
+        return '#FFD700'; // ذهبي للمالك
+      case 'admin':
+        return '#FF4444'; // أحمر للمشرف العام
+      case 'moderator':
+        return '#4A90E2'; // أزرق للمشرف
+      case 'member':
+        return '#2ECC71'; // أخضر للعضو
+      case 'guest':
+        return '#95A5A6'; // رمادي للزائر
+      default:
+        return '#000000';
+    }
+  }
+  
+  return '#000000';
 };
 
 // ===== نظام موحد جديد لتأثيرات صندوق المستخدم مع الملف الشخصي =====

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -267,14 +267,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(404).json({ error: 'المستخدم غير موجود' });
         }
 
-        // التحقق من الصلاحيات - فقط المشرفين يمكنهم رفع الصور
-        if (user.userType !== 'owner' && user.userType !== 'admin' && user.userType !== 'moderator') {
+        // التحقق من الصلاحيات - الأعضاء والمشرفين يمكنهم رفع الصور، الزوار لا يمكنهم
+        if (user.userType === 'guest') {
           try {
             await fsp.unlink(req.file.path);
           } catch (unlinkError) {
             console.error('خطأ في حذف الملف:', unlinkError);
           }
-          return res.status(403).json({ error: 'هذه الميزة متاحة للمشرفين فقط' });
+          return res.status(403).json({ error: 'هذه الميزة غير متاحة للزوار' });
         }
 
         // 🧠 استخدام النظام الذكي الجديد لمعالجة الصور

--- a/server/routes/stories.ts
+++ b/server/routes/stories.ts
@@ -65,7 +65,7 @@ router.post('/upload', protect.member, limiters.upload, upload.single('story'), 
     const userId = (req as any)?.user?.id as number;
     if (!userId) return res.status(401).json({ error: 'يجب تسجيل الدخول' });
 
-    // التحقق من الصلاحيات - فقط المشرفين يمكنهم رفع الستوري
+    // التحقق من الصلاحيات - الأعضاء والمشرفين يمكنهم رفع الستوري، الزوار لا يمكنهم
     const user = await storage.getUser(userId);
     if (!user) {
       if (req.file) {
@@ -74,11 +74,11 @@ router.post('/upload', protect.member, limiters.upload, upload.single('story'), 
       return res.status(404).json({ error: 'المستخدم غير موجود' });
     }
     
-    if (user.userType !== 'owner' && user.userType !== 'admin' && user.userType !== 'moderator') {
+    if (user.userType === 'guest') {
       if (req.file) {
         try { await fsp.unlink(req.file.path); } catch {}
       }
-      return res.status(403).json({ error: 'هذه الميزة متاحة للمشرفين فقط' });
+      return res.status(403).json({ error: 'هذه الميزة غير متاحة للزوار' });
     }
 
     if (!req.file) return res.status(400).json({ error: 'لم يتم رفع أي ملف' });


### PR DESCRIPTION
Enable members to upload profile pictures and stories, customize their profile, and display a distinct username color, while restricting these features for guests.

The user requested to elevate the capabilities of "members" to be similar to "moderators" for specific features like image uploads, profile customization, and story uploads, while ensuring "guests" remain restricted. This change implements those specific privilege adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-6961ef63-03a6-4d2a-87a7-f198f6a62e5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6961ef63-03a6-4d2a-87a7-f198f6a62e5f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

