### PR TITLE
Implement profile image and customization rules by level

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -639,20 +639,20 @@ export default function ProfileModal({
     event: React.ChangeEvent<HTMLInputElement>,
     uploadType: 'profile' | 'banner' = 'profile'
   ) => {
-    // التحقق من الصلاحيات
-    const isAuthorized = currentUser && (
-      currentUser.userType === 'owner' || 
-      currentUser.userType === 'admin' || 
-      currentUser.userType === 'moderator'
-    );
-    
-    if (!isAuthorized) {
-      toast({
-        title: 'غير مسموح',
-        description: 'هذه الميزة متاحة للمشرفين فقط',
-        variant: 'destructive',
-      });
-      return;
+    // التحقق من الصلاحيات: الصورة الشخصية متاحة لكل الأعضاء، الغلاف للمشرفين أو لفل 20+
+    const isModerator = !!currentUser && (currentUser.userType === 'owner' || currentUser.userType === 'admin' || currentUser.userType === 'moderator');
+    const lvl = Number(currentUser?.level || 1);
+    if (uploadType === 'banner') {
+      const canUploadBanner = isModerator || lvl >= 20;
+      if (!canUploadBanner) {
+        toast({ title: 'غير مسموح', description: 'الغلاف للمشرفين أو للمستوى 20 فما فوق', variant: 'destructive' });
+        return;
+      }
+    } else {
+      if (!currentUser || currentUser.userType === 'guest') {
+        toast({ title: 'غير مسموح', description: 'هذه الميزة غير متاحة للزوار', variant: 'destructive' });
+        return;
+      }
     }
 
     const file = event.target.files?.[0];
@@ -2123,12 +2123,11 @@ export default function ProfileModal({
                 )}
               </>
             )}
-            {localUser?.id === currentUser?.id && 
-             currentUser && (
+            {localUser?.id === currentUser?.id && currentUser && ((
                currentUser.userType === 'owner' || 
                currentUser.userType === 'admin' || 
                currentUser.userType === 'moderator'
-             ) && (
+             ) || (typeof currentUser.level === 'number' && currentUser.level >= 20)) && (
               <>
                 <button
                   className="change-cover-btn"

--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -82,11 +82,7 @@ export default function SettingsMenu({
             </Button>
           )}
 
-          {currentUser && (
-            currentUser.userType === 'owner' || 
-            currentUser.userType === 'admin' || 
-            currentUser.userType === 'moderator'
-          ) && (
+          {currentUser && currentUser.userType !== 'guest' && (
             <Button
               onClick={onOpenUsernameColorPicker}
               variant="ghost"
@@ -98,11 +94,7 @@ export default function SettingsMenu({
             </Button>
           )}
 
-          {currentUser && (
-            currentUser.userType === 'owner' || 
-            currentUser.userType === 'admin' || 
-            currentUser.userType === 'moderator'
-          ) && (
+          {currentUser && currentUser.userType !== 'guest' && (
             <Button
               onClick={onOpenStories}
               variant="ghost"

--- a/client/src/components/profile/ProfileBanner.tsx
+++ b/client/src/components/profile/ProfileBanner.tsx
@@ -33,6 +33,13 @@ export default function ProfileBanner({ currentUser, onBannerUpdate }: ProfileBa
       });
       return;
     }
+    // السماح برفع البانر فقط للمشرفين أو للمستوى 20+
+    const isModerator = ['owner', 'admin', 'moderator'].includes(currentUser.userType);
+    const lvl = Number(currentUser.level || 1);
+    if (!isModerator && lvl < 20) {
+      toast({ title: 'غير مسموح', description: 'الغلاف للمشرفين أو للمستوى 20 فما فوق', variant: 'destructive' });
+      return;
+    }
 
     const validation = validateFile(file, 'profile_banner');
     if (!validation.isValid) {
@@ -148,24 +155,38 @@ export default function ProfileBanner({ currentUser, onBannerUpdate }: ProfileBa
         {/* أزرار التحكم */}
         <div className="absolute bottom-3 right-3 flex gap-3">
           {/* زر الكاميرا */}
-          <Button
-            onClick={() => cameraInputRef.current?.click()}
-            disabled={uploading}
-            size="sm"
-            className="bg-white/20 backdrop-blur-md hover:bg-white/30 text-white border border-white/30 rounded-full w-10 h-10 p-0 shadow-lg transition-all duration-200 hover:scale-110"
-          >
-            <Camera size={16} />
-          </Button>
+          {(() => {
+            const isModerator = !!currentUser && ['owner', 'admin', 'moderator'].includes(currentUser.userType);
+            const lvl = Number(currentUser?.level || 1);
+            const canUploadBanner = isModerator || lvl >= 20;
+            return canUploadBanner ? (
+              <Button
+                onClick={() => cameraInputRef.current?.click()}
+                disabled={uploading}
+                size="sm"
+                className="bg-white/20 backdrop-blur-md hover:bg-white/30 text-white border border-white/30 rounded-full w-10 h-10 p-0 shadow-lg transition-all duration-200 hover:scale-110"
+              >
+                <Camera size={16} />
+              </Button>
+            ) : null;
+          })()}
 
           {/* زر رفع الملف */}
-          <Button
-            onClick={() => fileInputRef.current?.click()}
-            disabled={uploading}
-            size="sm"
-            className="bg-white/20 backdrop-blur-md hover:bg-white/30 text-white border border-white/30 rounded-full w-10 h-10 p-0 shadow-lg transition-all duration-200 hover:scale-110"
-          >
-            <Upload size={16} />
-          </Button>
+          {(() => {
+            const isModerator = !!currentUser && ['owner', 'admin', 'moderator'].includes(currentUser.userType);
+            const lvl = Number(currentUser?.level || 1);
+            const canUploadBanner = isModerator || lvl >= 20;
+            return canUploadBanner ? (
+              <Button
+                onClick={() => fileInputRef.current?.click()}
+                disabled={uploading}
+                size="sm"
+                className="bg-white/20 backdrop-blur-md hover:bg-white/30 text-white border border-white/30 rounded-full w-10 h-10 p-0 shadow-lg transition-all duration-200 hover:scale-110"
+              >
+                <Upload size={16} />
+              </Button>
+            ) : null;
+          })()}
         </div>
       </div>
 

--- a/client/src/components/ui/StoriesSettings.tsx
+++ b/client/src/components/ui/StoriesSettings.tsx
@@ -115,7 +115,7 @@ export default function StoriesSettings({ isOpen, onClose, currentUser }: Storie
             <TabsContent value="add" className="space-y-3">
               {!isAuthorized ? (
                 <div className="text-slate-400 text-sm text-center p-4">
-                  هذه الميزة متاحة للمشرفين فقط
+                  هذه الميزة غير متاحة للزوار
                 </div>
               ) : (
                 <>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -402,12 +402,14 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(404).json({ error: 'المستخدم غير موجود' });
         }
 
-        // التحقق من الصلاحيات - فقط المشرفين يمكنهم رفع البانر
-        if (user.userType !== 'owner' && user.userType !== 'admin' && user.userType !== 'moderator') {
+        // التحقق من الصلاحيات - المشرفون أو المستخدمون بمستوى 20+
+        const isModerator = user.userType === 'owner' || user.userType === 'admin' || user.userType === 'moderator';
+        const userLevel = Number((user as any).level || 1);
+        if (!isModerator && userLevel < 20) {
           try {
             await fsp.unlink(req.file.path);
           } catch {}
-          return res.status(403).json({ error: 'هذه الميزة متاحة للمشرفين فقط' });
+          return res.status(403).json({ error: 'هذه الميزة متاحة للمشرفين أو للمستوى 20 فما فوق' });
         }
 
         // 🧠 استخدام النظام الذكي الجديد لمعالجة البانر
@@ -1339,10 +1341,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ error: 'المستخدم غير موجود' });
       }
 
-      // التحقق من الصلاحيات - فقط المشرفين يمكنهم تغيير لون الاسم
-      if (user.userType !== 'owner' && user.userType !== 'admin' && user.userType !== 'moderator') {
-        return res.status(403).json({ error: 'هذه الميزة متاحة للمشرفين فقط' });
-      }
+      // فتح تغيير لون الاسم للجميع (مع حماية الملكية)
 
       // تحديث لون الاسم
       await storage.updateUser(userIdNum, { usernameColor: color });
@@ -1985,7 +1984,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: 'المستخدم غير موجود' });
       }
 
-      // Update username color
+      // Update username color (open to all members)
       await storage.updateUser(userId, { usernameColor: color });
 
       // بث خفيف مخصص للغرف + كامل لصاحب التعديل
@@ -2759,7 +2758,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // User Update Route with Theme Support
-  app.put('/api/users/:id', async (req, res) => {
+  app.put('/api/users/:id', protect.ownership, async (req, res) => {
     try {
       const { id } = req.params;
       const idNum = parseInt(id);


### PR DESCRIPTION
Implement granular permission controls for profile image uploads, story posting, and username color based on user level and role.

This PR modifies server-side and client-side logic to differentiate access: profile avatars are open to all members, profile banners are restricted to moderators or users level 20+, stories are open to all members, and username color is now available to all members, while other profile effects remain moderator-only.

---
<a href="https://cursor.com/background-agent?bcId=bc-95000eeb-8787-49ab-aca6-f5758f382ba8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-95000eeb-8787-49ab-aca6-f5758f382ba8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

