### PR TITLE
Fix admin user star display and icon

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2153,12 +2153,11 @@ export default function ProfileModal({
                     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                       <span style={{ fontSize: '14px' }}>
                         {localUser?.userType === 'owner' && 'Owner'}
-                        {localUser?.userType === 'admin' && 'Super Admin'}
+                        {localUser?.userType === 'admin' && 'Admin'}
                         {localUser?.userType === 'moderator' && 'Moderator'}
                       </span>
                       <span style={{ fontSize: '16px' }}>
                         {getUserLevelIcon(localUser, 16)}
-                        {localUser?.userType === 'admin' && '⭐'}
                       </span>
                     </div>
                   )}
@@ -2197,12 +2196,11 @@ export default function ProfileModal({
                     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
                       <span style={{ fontSize: '14px' }}>
                         {localUser?.userType === 'owner' && 'Owner'}
-                        {localUser?.userType === 'admin' && 'Super Admin'}
+                        {localUser?.userType === 'admin' && 'Admin'}
                         {localUser?.userType === 'moderator' && 'Moderator'}
                       </span>
                       <span style={{ fontSize: '16px' }}>
                         {getUserLevelIcon(localUser, 16)}
-                        {localUser?.userType === 'admin' && '⭐'}
                       </span>
                     </div>
                   )}


### PR DESCRIPTION
Corrects the display of the admin role in the profile modal from "Super Admin ⭐⭐" to "Admin ⭐".

---
<a href="https://cursor.com/background-agent?bcId=bc-635f5e83-a159-4141-bac6-0533a0926d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-635f5e83-a159-4141-bac6-0533a0926d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

