### PR TITLE
Investigate yellow frame in group chats

### DIFF
--- a/client/src/components/chat/ProfileImage.tsx
+++ b/client/src/components/chat/ProfileImage.tsx
@@ -31,9 +31,8 @@ export default function ProfileImage({
   
   // إضافة تأثير متدرج للإطار حسب مستوى المستخدم
   const gradientBorder = useMemo(() => {
-    if (user.role === 'owner') {
-      return 'linear-gradient(135deg, #FFD700, #FFA500, #FF6347)';
-    } else if (user.role === 'admin') {
+    // تم إزالة الإطار الخاص بالمالك
+    if (user.role === 'admin') {
       return 'linear-gradient(135deg, #4B0082, #8A2BE2, #9400D3)';
     } else if (user.role === 'moderator') {
       return 'linear-gradient(135deg, #008000, #32CD32, #00FF00)';


### PR DESCRIPTION
Remove the yellow/gold gradient border from the owner's profile image in chat.

---
<a href="https://cursor.com/background-agent?bcId=bc-69c796ff-d63b-49ec-a678-9ce29c97750d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-69c796ff-d63b-49ec-a678-9ce29c97750d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

