### PR TITLE
Fix profile music auto-play

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -27,6 +27,8 @@ interface ProfileModalProps {
   onPrivateMessage?: (user: ChatUser) => void;
   onAddFriend?: (user: ChatUser) => void;
   onReportUser?: (user: ChatUser) => void;
+  // عند التفعيل: يتم إدارة الصوت خارجياً من ChatInterface
+  externalAudioManaged?: boolean;
 }
 
 export default function ProfileModal({
@@ -38,6 +40,7 @@ export default function ProfileModal({
   onPrivateMessage,
   onAddFriend,
   onReportUser,
+  externalAudioManaged,
 }: ProfileModalProps) {
   const { toast } = useToast();
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -81,8 +84,9 @@ export default function ProfileModal({
     }
   }, [musicVolume, localUser?.profileMusicUrl]);
   
-  // تشغيل الموسيقى تلقائياً عند فتح البروفايل
+  // تشغيل الموسيقى تلقائياً عند فتح البروفايل (معطّل إذا كانت مُدارة خارجياً)
   useEffect(() => {
+    if (externalAudioManaged) return;
     if (localUser?.profileMusicUrl && musicEnabled && audioRef.current) {
       let attempts = 0;
       const maxAttempts = 3;
@@ -162,7 +166,7 @@ export default function ProfileModal({
         document.removeEventListener('touchstart', playAudio);
       };
     }
-  }, [localUser?.profileMusicUrl, musicEnabled, musicVolume]);
+  }, [localUser?.profileMusicUrl, musicEnabled, musicVolume, externalAudioManaged]);
   
   // معالج أخطاء الصوت
   const handleAudioError = () => {
@@ -2228,7 +2232,7 @@ export default function ProfileModal({
                   <audio
                     ref={audioRef}
                     src={localUser.profileMusicUrl}
-                    autoPlay
+                    {...(externalAudioManaged ? {} : { autoPlay: true })}
                     loop
                     style={{ display: 'none' }}
                     onError={handleAudioError}
@@ -2242,7 +2246,7 @@ export default function ProfileModal({
                   <audio
                     ref={audioRef}
                     src={localUser.profileMusicUrl}
-                    autoPlay
+                    {...(externalAudioManaged ? {} : { autoPlay: true })}
                     loop
                     style={{ display: 'none' }}
                     onError={handleAudioError}


### PR DESCRIPTION
Centralize profile music playback to ensure reliable autoplay on every profile view, addressing browser restrictions.

The previous profile music autoplay was unreliable and often failed due to browser restrictions. This change centralizes audio management in the main chat interface, ensuring music plays consistently every time a profile is opened and properly handling browser autoplay policies.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4f6e4a3-56e0-4e27-9b1f-46444848a19d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4f6e4a3-56e0-4e27-9b1f-46444848a19d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

