### PR TITLE
Build failed due to syntax error

### DIFF
--- a/client/src/components/chat/CountryWelcomeScreen.tsx
+++ b/client/src/components/chat/CountryWelcomeScreen.tsx
@@ -381,9 +381,9 @@ export default function CountryWelcomeScreen({ onUserLogin, countryData, topicSl
             </div>
           </div>
 
-          {/* Country Specific Chat Links */
-          {/* First-level topics inside the selected country */}
-          <div className="glass-effect p-8 rounded-2xl border border-white/20 mb-8">
+          <>
+            {/* Country Specific Chat Links - First-level topics inside the selected country */}
+            <div className="glass-effect p-8 rounded-2xl border border-white/20 mb-8">
             <h2 className="text-3xl font-bold text-center mb-6 text-white">
               غرف دردشة {countryData.nameAr.replace('شات ', '')} المتخصصة
             </h2>
@@ -484,6 +484,7 @@ export default function CountryWelcomeScreen({ onUserLogin, countryData, topicSl
               <a href="/morocco" className="text-blue-300 hover:text-blue-200 transition-colors">شات المغرب</a>
             </div>
           </div>
+          </>
         </div>
       </div>
 


### PR DESCRIPTION
Fix JSX build errors in `CountryWelcomeScreen.tsx` by correcting comment syntax and wrapping sibling elements in a React Fragment.

The build failed due to an extra `}` in a JSX comment and subsequent JSX parsing errors where multiple sibling elements (including comments) were not wrapped in a single parent or React Fragment. The fix involves removing the extraneous `}` and wrapping the affected JSX block in a React Fragment, as well as combining adjacent comments.

---
<a href="https://cursor.com/background-agent?bcId=bc-7126a147-97ce-4bd9-a3d8-75b45a38d68a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7126a147-97ce-4bd9-a3d8-75b45a38d68a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

