### PR TITLE
Build and run project with esm error

### DIFF
--- a/server/bot-system/logger.ts
+++ b/server/bot-system/logger.ts
@@ -2,8 +2,14 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { fileURLToPath } from 'url';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+let __dirname: string;
+try {
+  const __filename = fileURLToPath(import.meta.url);
+  __dirname = path.dirname(__filename);
+} catch (e) {
+  // Fallback for production build
+  __dirname = process.cwd();
+}
 
 enum LogLevel {
   DEBUG = 0,
@@ -18,7 +24,8 @@ class BotLogger {
   private writeStream: fs.WriteStream | null = null;
 
   constructor() {
-    const logsDir = path.join(__dirname, '../../../logs/bot-system');
+    // Use a path relative to the project root instead
+    const logsDir = path.join(process.cwd(), 'logs', 'bot-system');
     if (!fs.existsSync(logsDir)) {
       fs.mkdirSync(logsDir, { recursive: true });
     }


### PR DESCRIPTION
Fix `__dirname` not defined error in ES module scope by using `process.cwd()` for log directory path.

The application failed to start in production due to `__dirname` being undefined when running as an ES module. This PR provides a fallback to `process.cwd()` for determining the base directory, ensuring the log directory path is correctly resolved in all environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-816bffb0-58f5-4eb4-a187-47dc44a629b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-816bffb0-58f5-4eb4-a187-47dc44a629b0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

