### PR TITLE
Troubleshoot bot startup failure

### DIFF
--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -141,18 +141,66 @@ export async function apiRequest<T = any>(
 
 // Helper methods for better type safety
 export const api = {
-  get: <T = any>(endpoint: string): Promise<T> => apiRequest<T>(endpoint, { method: 'GET' }),
+  get: <T = any>(
+    endpoint: string,
+    options?: { headers?: Record<string, string>; timeout?: number; signal?: AbortSignal }
+  ): Promise<T> =>
+    apiRequest<T>(endpoint, {
+      method: 'GET',
+      headers: options?.headers,
+      timeout: options?.timeout,
+      signal: options?.signal,
+    }),
 
-  post: <T = any>(endpoint: string, data?: any): Promise<T> =>
-    apiRequest<T>(endpoint, { method: 'POST', body: data }),
+  post: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: { headers?: Record<string, string>; timeout?: number; signal?: AbortSignal }
+  ): Promise<T> =>
+    apiRequest<T>(endpoint, {
+      method: 'POST',
+      body: data,
+      headers: options?.headers,
+      timeout: options?.timeout,
+      signal: options?.signal,
+    }),
 
-  put: <T = any>(endpoint: string, data?: any): Promise<T> =>
-    apiRequest<T>(endpoint, { method: 'PUT', body: data }),
+  put: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: { headers?: Record<string, string>; timeout?: number; signal?: AbortSignal }
+  ): Promise<T> =>
+    apiRequest<T>(endpoint, {
+      method: 'PUT',
+      body: data,
+      headers: options?.headers,
+      timeout: options?.timeout,
+      signal: options?.signal,
+    }),
 
-  delete: <T = any>(endpoint: string): Promise<T> => apiRequest<T>(endpoint, { method: 'DELETE' }),
+  delete: <T = any>(
+    endpoint: string,
+    options?: { headers?: Record<string, string>; timeout?: number; signal?: AbortSignal }
+  ): Promise<T> =>
+    apiRequest<T>(endpoint, {
+      method: 'DELETE',
+      headers: options?.headers,
+      timeout: options?.timeout,
+      signal: options?.signal,
+    }),
 
-  patch: <T = any>(endpoint: string, data?: any): Promise<T> =>
-    apiRequest<T>(endpoint, { method: 'PATCH', body: data }),
+  patch: <T = any>(
+    endpoint: string,
+    data?: any,
+    options?: { headers?: Record<string, string>; timeout?: number; signal?: AbortSignal }
+  ): Promise<T> =>
+    apiRequest<T>(endpoint, {
+      method: 'PATCH',
+      body: data,
+      headers: options?.headers,
+      timeout: options?.timeout,
+      signal: options?.signal,
+    }),
 
   // دالة مخصصة لرفع الملفات
   upload: <T = any>(

--- a/client/src/pages/admin/BotControl.tsx
+++ b/client/src/pages/admin/BotControl.tsx
@@ -109,7 +109,7 @@ export function BotControl() {
 
     try {
       const headers = adminToken ? { Authorization: `Bearer ${adminToken}` } : undefined;
-      await api.post(`/api/admin/bots/${selectedBot.id}/message`, { message, ...(headers ? { headers } : {}) } as any);
+      await api.post(`/api/admin/bots/${selectedBot.id}/message`, { message }, { headers } as any);
       setMessage('');
       setAlert({ type: 'success', message: 'تم إرسال الرسالة بنجاح' });
     } catch (error) {
@@ -122,7 +122,7 @@ export function BotControl() {
 
     try {
       const headers = adminToken ? { Authorization: `Bearer ${adminToken}` } : undefined;
-      await api.post(`/api/admin/bots/${selectedBot.id}/move`, { room: selectedRoom, ...(headers ? { headers } : {}) } as any);
+      await api.post(`/api/admin/bots/${selectedBot.id}/move`, { room: selectedRoom }, { headers } as any);
       setAlert({ type: 'success', message: 'تم نقل البوت بنجاح' });
       loadBotData();
     } catch (error) {
@@ -133,7 +133,7 @@ export function BotControl() {
   const executeCommand = async (command: string) => {
     try {
       const headers = adminToken ? { Authorization: `Bearer ${adminToken}` } : undefined;
-      await api.post('/api/admin/bots/command', { command, ...(headers ? { headers } : {}) } as any);
+      await api.post('/api/admin/bots/command', { command }, { headers } as any);
       setAlert({ type: 'success', message: 'تم تنفيذ الأمر بنجاح' });
       loadBotData();
     } catch (error) {


### PR DESCRIPTION
Refactor API calls to correctly send `Authorization` headers instead of including them in the request body, fixing bot control authentication failures.

The bot control operations (e.g., `start_all`) were failing because the `Authorization` token was incorrectly sent within the request body data. This PR updates the `api` utility to support passing headers via an options object and modifies `BotControl.tsx` to use this new functionality, ensuring proper authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-70a7e2e9-9fb1-47a1-9abf-7de86f937b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70a7e2e9-9fb1-47a1-9abf-7de86f937b34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

