### PR TITLE
Add user role images and logos to bot management

### DIFF
--- a/client/src/utils/themeUtils.ts
+++ b/client/src/utils/themeUtils.ts
@@ -218,7 +218,7 @@ export const getUserEffectStyles = (user: any): Record<string, string> => {
 export const getUserListItemStyles = (user: any): Record<string, string> => {
   // فقط المشرفين والإدمن والمالك يحصلون على تأثيرات خاصة
   // الزوار والأعضاء العاديين بدون لون خلفية
-  if (user?.userType === 'guest' || user?.userType === 'member') {
+  if (user?.userType === 'guest' || user?.userType === 'member' || user?.userType === 'bot') {
     // إرجاع كائن فارغ للزوار والأعضاء (بدون ألوان خلفية)
     return {};
   }
@@ -232,7 +232,7 @@ export const getUserListItemClasses = (user: any): string => {
   const classes = [] as string[];
 
   // فقط المشرفين والإدمن والمالك يحصلون على كلاسات التأثيرات
-  if (user?.userType === 'guest' || user?.userType === 'member') {
+  if (user?.userType === 'guest' || user?.userType === 'member' || user?.userType === 'bot') {
     // إرجاع كلاس فارغ للزوار والأعضاء
     return '';
   }


### PR DESCRIPTION
Add gender and profile image fields to the 'Add Bot' form, remove bot type/status, and standardize bot list item styling to match regular users.

---
<a href="https://cursor.com/background-agent?bcId=bc-203c33e7-0d3e-4c0e-86fd-6cad8aa7c722">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-203c33e7-0d3e-4c0e-86fd-6cad8aa7c722">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

