### PR TITLE
Replace status with gender symbols

### DIFF
--- a/client/src/components/chat/bots/BotsManagement.tsx
+++ b/client/src/components/chat/bots/BotsManagement.tsx
@@ -450,7 +450,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
                     </TableCell>
                     <TableCell>
                       <span className={`text-sm px-2 py-1 rounded-full ${bot.isOnline ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
-                        {bot.isOnline ? '🟢 متصل' : '⚫ غير متصل'}
+                        {`${bot.gender === 'female' ? '♀' : '♂'} ${bot.isOnline ? 'متصل' : 'غير متصل'}`}
                       </span>
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
Replace bot status circle with gender symbol and text in `BotsManagement.tsx`.

The user requested to replace the default status circle with a gender symbol (♂/♀) and status text for bots in the bots management panel, as the previous bot icon was not displaying as desired.

---
<a href="https://cursor.com/background-agent?bcId=bc-d6838f67-834a-4de7-8bb3-69271b1e08d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d6838f67-834a-4de7-8bb3-69271b1e08d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

