### PR TITLE
Fix bot contact display issue

### DIFF
--- a/client/src/components/chat/bots/BotsManagement.tsx
+++ b/client/src/components/chat/bots/BotsManagement.tsx
@@ -16,6 +16,7 @@ import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { getImageSrc } from '@/utils/imageUtils';
 import { validateFile, getUploadTimeout } from '@/lib/uploadConfig';
+import UserRoleBadge from '@/components/chat/UserRoleBadge';
 
 interface Bot {
   id: number;
@@ -417,7 +418,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
                 <TableRow>
                   <TableHead className="w-12 text-center">#</TableHead>
                   <TableHead>البوت</TableHead>
-                  <TableHead>الحالة</TableHead>
+                  <TableHead>الشعار</TableHead>
                   <TableHead>الغرفة</TableHead>
                   <TableHead>المستوى</TableHead>
                   <TableHead>النقاط</TableHead>
@@ -449,9 +450,18 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <span className={`text-sm px-2 py-1 rounded-full ${bot.isOnline ? 'bg-green-100 text-green-700' : 'bg-gray-100 text-gray-600'}`}>
-                        {bot.isOnline ? '🟢 متصل' : '⚫ غير متصل'}
-                      </span>
+                      <UserRoleBadge
+                        user={{
+                          id: bot.id,
+                          username: bot.username,
+                          role: 'member',
+                          isOnline: bot.isOnline,
+                          userType: 'member',
+                          gender: bot.gender,
+                          level: bot.level,
+                        } as unknown as ChatUser}
+                        size={20}
+                      />
                     </TableCell>
                     <TableCell>
                       <Badge variant="outline">{bot.currentRoom}</Badge>


### PR DESCRIPTION
Replace bot online/offline status display with gender badges in the bots management list to match member display.

---
<a href="https://cursor.com/background-agent?bcId=bc-32a8fd34-b573-477e-874b-b64ece54caa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-32a8fd34-b573-477e-874b-b64ece54caa1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

