### PR TITLE
Fix bot user list offline status

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1615,7 +1615,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                         </div>
                       )}
                       <span className="font-medium">
-                        {u ? u.username : `مستخدم غير متصل #${id}`}
+                        {u ? u.username : `مستخدم #${id}`}
                       </span>
                     </div>
                     <Button size="sm" variant="outline" onClick={() => chat.unignoreUser?.(id)}>

--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -438,20 +438,22 @@ export default function FriendsTabPanel({
                               {renderCountryFlag(friend)}
                             </div>
                           </div>
-                          {/* حالة الاتصال */}
-                          <div className="text-xs text-gray-500 mt-1">
-                            {friend.isOnline ? (
-                              <span className="flex items-center gap-1">
-                                <span className="w-2 h-2 bg-green-500 rounded-full"></span>
-                                {friend.status === 'away' ? 'بعيد' : 'متصل الآن'}
-                              </span>
-                            ) : (
-                              <span className="flex items-center gap-1">
-                                <span className="w-2 h-2 bg-gray-400 rounded-full"></span>
-                                غير متصل
-                              </span>
-                            )}
-                          </div>
+                          {/* حالة الاتصال - لا تُعرض للبوت */}
+                          {friend.userType !== 'bot' && (
+                            <div className="text-xs text-gray-500 mt-1">
+                              {friend.isOnline ? (
+                                <span className="flex items-center gap-1">
+                                  <span className="w-2 h-2 bg-green-500 rounded-full"></span>
+                                  {friend.status === 'away' ? 'بعيد' : 'متصل الآن'}
+                                </span>
+                              ) : (
+                                <span className="flex items-center gap-1">
+                                  <span className="w-2 h-2 bg-gray-400 rounded-full"></span>
+                                  غير متصل
+                                </span>
+                              )}
+                            </div>
+                          )}
                           {friend.lastMessage && (
                             <div className="text-xs text-gray-500 truncate">
                               {friend.lastMessage}

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2500,9 +2500,11 @@ export default function ProfileModal({
                   💰 إرسال النقاط: <span>اضغط للإرسال</span>
                 </p>
               )}
-              <p>
-                🧾 الحالة: <span>{localUser?.isOnline ? 'متصل' : 'غير متصل'}</span>
-              </p>
+              {localUser?.userType !== 'bot' && (
+                <p>
+                  🧾 الحالة: <span>{localUser?.isOnline ? 'متصل' : 'غير متصل'}</span>
+                </p>
+              )}
             </div>
 
             {localUser?.id === currentUser?.id && (


### PR DESCRIPTION
Remove "غير متصل" (offline) status display for bot users as bots do not have an online/offline state.

---
<a href="https://cursor.com/background-agent?bcId=bc-98e5e3ac-87d5-4db2-a804-4d199fbb20de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-98e5e3ac-87d5-4db2-a804-4d199fbb20de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

