### PR TITLE
Check for specific word in bot user list

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -213,6 +213,15 @@ export default function FriendsTabPanel({
         border: 'none',
       };
 
+      // تجاهل القيم النصية غير المرغوبة مثل "غير" أو قيم الجنس
+      const rawCountry = (user.country || '').trim();
+      const firstToken = rawCountry.split(' ')[0];
+      const lowered = firstToken.toLowerCase();
+      const invalidTokens = new Set<string>(['غير', 'غير-محدد', 'غير_محدد', 'ذكر', 'أنثى', 'انثى', 'male', 'female']);
+      if (firstToken && (invalidTokens.has(firstToken) || invalidTokens.has(lowered))) {
+        return null;
+      }
+
       if (emoji) {
         return (
           <span style={boxStyle} title={user.country}>

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -186,6 +186,15 @@ export default function UnifiedSidebar({
         border: 'none',
       };
 
+      // تجاهل القيم النصية غير المرغوبة مثل "غير" أو قيم الجنس
+      const rawCountry = (user.country || '').trim();
+      const firstToken = rawCountry.split(' ')[0];
+      const lowered = firstToken.toLowerCase();
+      const invalidTokens = new Set<string>(['غير', 'غير-محدد', 'غير_محدد', 'ذكر', 'أنثى', 'انثى', 'male', 'female']);
+      if (firstToken && (invalidTokens.has(firstToken) || invalidTokens.has(lowered))) {
+        return null;
+      }
+
       if (emoji) {
         return (
           <span style={boxStyle} title={user.country}>


### PR DESCRIPTION
Remove unwanted text like "غير" (unspecified) from user country badges in the sidebar and friends list.

The word "غير" was appearing incorrectly in the user list, making it seem like a user role, and the user requested its complete removal from the code. This change prevents specific invalid text tokens (e.g., "غير", "male", "female") from being rendered as country badges.

---
<a href="https://cursor.com/background-agent?bcId=bc-bea59bb3-9d6c-4839-a6b6-2086cec6b2f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bea59bb3-9d6c-4839-a6b6-2086cec6b2f8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

