### PR TITLE
Improve website zoom and remove scrollbar

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -112,7 +112,7 @@
     min-height: 100vh;
     position: relative;
     overflow-x: hidden;
-    font-size: 16px;
+    font-size: 1rem;
     line-height: 1.7;
     letter-spacing: 0.02em;
   }
@@ -174,6 +174,9 @@
   html {
     direction: rtl;
     scroll-behavior: smooth;
+    /* Stabilize layout and tune base sizing */
+    font-size: 90%;
+    scrollbar-gutter: stable both-edges;
   }
   
   /* Modern Scrollbar */

--- a/client/src/pages/ArabicChat.tsx
+++ b/client/src/pages/ArabicChat.tsx
@@ -13,7 +13,7 @@ export default function ArabicChat() {
   }, []);
 
   return (
-    <div className="p-6 min-h-[100dvh] bg-background text-foreground" dir="rtl">
+    <div className="p-6 min-h-[100dvh] bg-background text-foreground overflow-hidden" dir="rtl">
       <h1 className="text-2xl font-bold mb-2">شات عربي عام</h1>
       <p>دردشة عامة تجمع العرب في مكان واحد.</p>
     </div>

--- a/client/src/pages/CountryChat.tsx
+++ b/client/src/pages/CountryChat.tsx
@@ -99,7 +99,7 @@ export default function CountryChat() {
   }
 
   return (
-    <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo']" dir="rtl">
+    <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl">
       <Suspense fallback={<div className="p-6 text-center">...جاري التحميل</div>}>
         {isRestoring ? (
           <div className="p-6 text-center">...جاري استعادة الجلسة</div>

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -102,7 +102,7 @@ export default function ChatPage() {
   };
 
   return (
-    <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo']" dir="rtl">
+    <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl">
       <Suspense fallback={<div className="p-6 text-center">...جاري التحميل</div>}>
         {isRestoring ? (
           <div className="p-6 text-center">...جاري استعادة الجلسة</div>


### PR DESCRIPTION
Adjust base font size and stabilize scrollbar gutter to optimize default zoom level and eliminate page jitter when opening user lists.

The user reported that the site looked best at 90% browser zoom and experienced a page shake when opening the user list, caused by the scrollbar appearing/disappearing. These changes set a global `font-size: 90%` on `html` and use `scrollbar-gutter: stable both-edges` to reserve space for the scrollbar, along with `overflow-hidden` on chat page wrappers to prevent the root scrollbar from appearing.

---
<a href="https://cursor.com/background-agent?bcId=bc-fb1ed99b-9d34-48fb-b485-29b75a339748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fb1ed99b-9d34-48fb-b485-29b75a339748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

