### PR TITLE
Debug profile size increase after optimization

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1466,7 +1466,7 @@ export default function ProfileModal({
           border-radius: 8px;
           padding: 8px 12px;
           color: #fff;
-          font-size: 12px;
+          font-size: 0.75rem;
           cursor: pointer;
           z-index: 3;
           transition: background 0.3s ease;
@@ -1497,7 +1497,7 @@ export default function ProfileModal({
           padding: 3px 6px; /* تصغير المساحة الداخلية للأزرار أكثر ليظهر زر البلاغ */
           border-radius: 6px;
           font-weight: 600;
-          font-size: 10px; /* تصغير النص ليبقى كل الأزرار ضمن نفس المنطقة */
+          font-size: 0.625rem; /* تصغير النص ليبقى كل الأزرار ضمن نفس المنطقة */
           cursor: pointer;
           color: #fff;
           box-shadow: 0 4px 12px rgba(0,0,0,0.3);
@@ -1553,7 +1553,7 @@ export default function ProfileModal({
           height: 30px;
           text-align: center;
           line-height: 30px;
-          font-size: 14px;
+          font-size: 0.875rem;
           color: #fff;
           cursor: pointer;
           z-index: 3;
@@ -1582,7 +1582,7 @@ export default function ProfileModal({
 
         .profile-info h3 {
           margin: 0 0 6px 0;
-          font-size: 20px;
+          font-size: 1.25rem;
           font-weight: bold;
           color: var(--accent-color);
           text-shadow: 0 2px 4px rgba(0,0,0,0.5);
@@ -1597,7 +1597,7 @@ export default function ProfileModal({
 
         .profile-info small {
           display: block;
-          font-size: 13px;
+          font-size: 0.8125rem;
           color: #ddd;
           opacity: 0.9;
           cursor: pointer;
@@ -1626,7 +1626,7 @@ export default function ProfileModal({
           border-radius: 8px;
           font-weight: bold;
           cursor: pointer;
-          font-size: 12px;
+          font-size: 0.75rem;
           transition: all 0.3s ease;
           box-shadow: 0 4px 12px rgba(0,0,0,0.3);
           border: 1px solid rgba(255,255,255,0.1);
@@ -1646,7 +1646,7 @@ export default function ProfileModal({
 
         .profile-details {
           padding: 12px;
-          font-size: 13px;
+          font-size: 0.8125rem;
           background: rgba(255,255,255,0.08);
           border-radius: 12px;
           margin: 12px 0;
@@ -1697,7 +1697,7 @@ export default function ProfileModal({
 
         .additional-details p {
           margin: 6px 0;
-          font-size: 12px;
+          font-size: 0.75rem;
           color: #eee;
           display: flex;
           justify-content: space-between;
@@ -1748,7 +1748,7 @@ export default function ProfileModal({
           margin: 0 0 16px 0;
           color: var(--accent-color);
           text-align: center;
-          font-size: 18px;
+          font-size: 1.125rem;
         }
         
         .edit-field {
@@ -1760,7 +1760,7 @@ export default function ProfileModal({
           margin-bottom: 6px;
           color: #fff;
           font-weight: bold;
-          font-size: 14px;
+          font-size: 0.875rem;
         }
         
         .edit-field input, .edit-field select, .edit-field textarea {
@@ -1770,7 +1770,7 @@ export default function ProfileModal({
           border-radius: 10px;
           background: linear-gradient(135deg, rgba(255,255,255,0.15), rgba(255,255,255,0.05));
           color: #fff;
-          font-size: 14px;
+          font-size: 0.875rem;
           font-weight: 500;
           backdrop-filter: blur(10px);
           transition: all 0.3s ease;
@@ -1838,7 +1838,7 @@ export default function ProfileModal({
 
         .theme-name {
           flex: 1;
-          font-size: 14px;
+          font-size: 0.875rem;
           font-weight: 500;
         }
 
@@ -1992,7 +1992,7 @@ export default function ProfileModal({
           position: absolute;
           top: 10px;
           right: 10px;
-          font-size: 20px;
+          font-size: 1.25rem;
           animation: starFloat 4s ease-in-out infinite;
           z-index: 10;
           pointer-events: none;
@@ -2003,7 +2003,7 @@ export default function ProfileModal({
           position: absolute;
           bottom: 10px;
           left: 10px;
-          font-size: 16px;
+          font-size: 1rem;
           animation: starFloat 3s ease-in-out infinite reverse;
           z-index: 10;
           pointer-events: none;
@@ -2042,7 +2042,7 @@ export default function ProfileModal({
           position: absolute;
           top: -20px;
           left: 20%;
-          font-size: 16px;
+          font-size: 1rem;
           animation: snowfall 5s linear infinite;
           z-index: 10;
           pointer-events: none;
@@ -2053,7 +2053,7 @@ export default function ProfileModal({
           position: absolute;
           top: -20px;
           right: 30%;
-          font-size: 12px;
+          font-size: 0.75rem;
           animation: snowfall 6s linear infinite 2s;
           z-index: 10;
           pointer-events: none;
@@ -2082,7 +2082,7 @@ export default function ProfileModal({
           position: absolute;
           bottom: 10px;
           right: 10px;
-          font-size: 18px;
+          font-size: 1.125rem;
           animation: smokeRise 4s ease-in-out infinite;
           z-index: 10;
           pointer-events: none;
@@ -2103,7 +2103,7 @@ export default function ProfileModal({
           position: absolute;
           top: 15px;
           left: 15px;
-          font-size: 16px;
+          font-size: 1rem;
           animation: butterflyFly 6s ease-in-out infinite;
           z-index: 10;
           pointer-events: none;
@@ -2130,7 +2130,7 @@ export default function ProfileModal({
           font-weight: bold;
           cursor: pointer;
           transition: all 0.3s;
-          font-size: 13px;
+          font-size: 0.8125rem;
         }
 
         .save-btn {
@@ -2167,7 +2167,7 @@ export default function ProfileModal({
             width: 25px;
             height: 25px;
             line-height: 25px;
-            font-size: 12px;
+            font-size: 0.75rem;
           }
           
           .profile-body {
@@ -2175,7 +2175,7 @@ export default function ProfileModal({
           }
           
           .profile-info h3 {
-            font-size: 18px;
+            font-size: 1.125rem;
           }
           
           /* أنماط الأزرار للأجهزة المحمولة */
@@ -2188,7 +2188,7 @@ export default function ProfileModal({
           
           .profile-actions button {
             padding: 4px 6px;
-            font-size: 10px;
+            font-size: 0.625rem;
           }
         }
       `}</style>


### PR DESCRIPTION
Convert `font-size` units from `px` to `rem` in `ProfileModal.tsx` to ensure the profile page scales correctly with global site size adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-79d77615-0053-4802-a4ad-8e137edfb21b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-79d77615-0053-4802-a4ad-8e137edfb21b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

