### PR TITLE
Analyze user list color discrepancy

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -490,7 +490,7 @@ export default function UnifiedSidebar({
       React.memo(({ user }: { user: ChatUser }) => {
         if (!user?.username || !user?.userType) return null;
         return (
-          <li key={user.id} className="relative list-none">
+          <div key={user.id} className="relative" role="listitem">
             <SimpleUserMenu
               targetUser={user}
               currentUser={currentUser}
@@ -524,7 +524,7 @@ export default function UnifiedSidebar({
                 </div>
               </div>
             </SimpleUserMenu>
-          </li>
+          </div>
         );
       }),
     [currentUser, isModerator, renderCountryFlag, renderUserBadge]
@@ -583,7 +583,7 @@ export default function UnifiedSidebar({
                 )}
               </div>
             ) : (
-              <div className="px-0">
+              <div className="px-0" role="list">
                 <Virtuoso
                   style={{ height: isMobile ? 'calc(100vh - 180px)' : 'calc(100vh - 260px)' }}
                   totalCount={filteredUsers.length}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1995,38 +1995,38 @@ a:hover::after {
   width: 100%;
 }
 
-/* Modern List Styles */
+/* Modern List Styles - keep neutral globally (avoid forcing bullets/padding) */
 ul, ol {
   list-style: none;
   padding-right: 0;
+  margin: 0;
 }
 
+/* Remove default li decorations globally to prevent side strips in virtual lists */
 li {
-  position: relative;
-  padding-right: 24px;
-  margin-bottom: 8px;
+  position: static;
+  padding: 0;
+  margin: 0;
 }
 
 li::before {
-  content: '◈';
-  position: absolute;
-  right: 0;
-  color: var(--primary-solid);
-  font-weight: bold;
+  content: none;
 }
 
-/* Reset default list markers and spacing inside the users list only */
+/* Users list container: ensure edge-to-edge rows and no pseudo-markers */
+.users-list-reset, .users-list-reset * {
+  list-style: none !important;
+}
+
+.users-list-reset [role="listitem"],
 .users-list-reset li {
-  padding-right: 0;
-  margin-bottom: 0;
+  margin: 0 !important;
+  padding: 0 !important;
 }
 
-.users-list-reset li::before {
-  content: '';
-}
-
-/* Fix for user list items in sidebar - remove pseudo element */
+.users-list-reset [role="listitem"]::before,
 .users-list-reset li::before,
+#root [role="listitem"]::before,
 #root li[class*="relative"]::before {
   content: none !important;
   display: none !important;


### PR DESCRIPTION
Adjust users list styling to remove the side color strip and ensure items span full width.

The "second color" strip was caused by global `li` styles applying padding and a `::before` pseudo-element (a bullet) which, when combined with the `Virtuoso` virtualized list, created an unwanted visible gap on the right side of the list items. This PR neutralizes these global `li` styles and updates list items to `div` with `role="listitem"` to ensure they take full width.

---
<a href="https://cursor.com/background-agent?bcId=bc-b908b3cf-2974-4e17-9f76-28501faa65d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b908b3cf-2974-4e17-9f76-28501faa65d2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

