### PR TITLE
Add real flags to profiles and user list

### DIFF
--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -17,7 +17,7 @@ import { useNotificationManager } from '@/hooks/useNotificationManager';
 import { apiRequest } from '@/lib/queryClient';
 import type { ChatUser } from '@/types/chat';
 import { getImageSrc } from '@/utils/imageUtils';
-import { getCountryFlag } from '@/utils';
+import CountryFlag from '@/components/ui/CountryFlag';
 import {
   getFinalUsernameColor,
   getUserListItemStyles,
@@ -194,34 +194,8 @@ export default function FriendsTabPanel({
     return <UserRoleBadge user={user} size={20} />;
   }, []);
 
-  const getCountryEmoji = useCallback((country?: string): string | null => getCountryFlag(country), []);
-
-  const renderCountryFlag = useCallback(
-    (user: ChatUser) => {
-      const emoji = getCountryEmoji(user.country);
-      const boxStyle: React.CSSProperties = {
-        width: 20,
-        height: 20,
-        borderRadius: 0,
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'transparent',
-        border: 'none',
-      };
-
-      if (emoji) {
-        return (
-          <span style={boxStyle} title={user.country}>
-            <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>
-          </span>
-        );
-      }
-
-      return null;
-    },
-    [getCountryEmoji]
-  );
+  // استبدال إيموجي العلم بصورة علم حقيقية
+  const renderCountryFlag = useCallback((user: ChatUser) => <CountryFlag country={user.country} size={14} />, []);
 
   // التحقق من صلاحيات الإشراف
   const isModerator = currentUser && ['moderator', 'admin', 'owner'].includes(currentUser.userType);

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/utils/themeUtils';
 import { getCountryFlag } from '@/utils';
 import { getUserLevelIcon } from '@/components/chat/UserRoleBadge';
+import CountryFlag from '@/components/ui/CountryFlag';
 import ProfileImage from './ProfileImage';
 import { useStories } from '@/hooks/useStories';
 
@@ -2485,7 +2486,10 @@ export default function ProfileModal({
                 onClick={() => localUser?.id === currentUser?.id && openEditModal('country')}
                 style={{ cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default' }}
               >
-                🌍 البلد: <span>{localUser?.country || 'غير محدد'}</span>
+                🌍 البلد: <span className="inline-flex items-center gap-1">
+                  {localUser?.country || 'غير محدد'}
+                  {localUser?.country && <CountryFlag country={localUser?.country} size={14} />}
+                </span>
               </p>
               <p
                 onClick={() => localUser?.id === currentUser?.id && openEditModal('age')}

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -32,7 +32,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { getSocket, saveSession } from '@/lib/socket';
 import type { ChatUser, WallPost, CreateWallPostData, ChatRoom } from '@/types/chat';
 import { getImageSrc } from '@/utils/imageUtils';
-import { getCountryFlag } from '@/utils';
+import CountryFlag from '@/components/ui/CountryFlag';
 import {
   getUserEffectStyles,
   getUserEffectClasses,
@@ -167,33 +167,9 @@ export default function UnifiedSidebar({
     return <UserRoleBadge user={user} size={20} />;
   }, []);
 
-  const getCountryEmoji = useCallback((country?: string): string | null => getCountryFlag(country), []);
-
+  // استبدال إيموجي العلم بصورة علم حقيقية
   const renderCountryFlag = useCallback(
-    (user: ChatUser) => {
-      const emoji = getCountryEmoji(user.country);
-      const boxStyle: React.CSSProperties = {
-        width: 20,
-        height: 20,
-        borderRadius: 0,
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'transparent',
-        border: 'none',
-      };
-
-      if (emoji) {
-        return (
-          <span style={boxStyle} title={user.country}>
-            <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>
-          </span>
-        );
-      }
-
-      return null;
-    },
-    [getCountryEmoji]
+    (user: ChatUser) => <CountryFlag country={user.country} size={14} />, []
   );
 
   // 🚀 تحسين: دالة formatLastSeen محسنة

--- a/client/src/components/ui/CountryFlag.tsx
+++ b/client/src/components/ui/CountryFlag.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import { getCountryFlagUrl } from '@/utils';
+
+interface CountryFlagProps {
+  country?: string | null;
+  size?: number; // pixel height; width will auto-scale for SVG
+  className?: string;
+  title?: string;
+}
+
+export default function CountryFlag({ country, size = 16, className = '', title }: CountryFlagProps) {
+  const url = getCountryFlagUrl(country || undefined);
+  if (!url) return null;
+
+  const alt = country || 'Country flag';
+  const style: React.CSSProperties = {
+    width: size * 1.5, // typical flag aspect ratio ~3:2
+    height: size,
+    display: 'inline-block',
+    objectFit: 'cover',
+    borderRadius: 2,
+  };
+
+  return (
+    <img
+      src={url}
+      alt={alt}
+      title={title || country || undefined}
+      style={style}
+      className={className}
+      loading="lazy"
+      referrerPolicy="no-referrer"
+    />
+  );
+}
+

--- a/client/src/components/ui/PremiumUserTheme.tsx
+++ b/client/src/components/ui/PremiumUserTheme.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 
 import { getUserLevelIcon } from '@/components/chat/UserRoleBadge';
-import { getCountryFlag } from '@/utils';
+import CountryFlag from '@/components/ui/CountryFlag';
 import type { ChatUser } from '@/types/chat';
 
 interface PremiumUserThemeProps {
@@ -48,11 +48,7 @@ export default function PremiumUserTheme({
         <div className="flex items-center gap-1">
           {children}
 
-          {showFlag && user.country && (
-            <span className="text-sm" title={user.country}>
-              {getCountryFlag(user.country)}
-            </span>
-          )}
+          {showFlag && user.country && <CountryFlag country={user.country} size={14} />}
         </div>
       </div>
     </div>

--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -4,7 +4,7 @@ import { apiRequest } from '@/lib/queryClient';
 import { getSocket } from '@/lib/socket';
 import type { ChatUser } from '@/types/chat';
 import { getImageSrc } from '@/utils/imageUtils';
-import { getCountryFlag } from '@/utils';
+import CountryFlag from '@/components/ui/CountryFlag';
 import { getFinalUsernameColor, getUserListItemClasses, getUserListItemStyles } from '@/utils/themeUtils';
 import ProfileImage from '@/components/chat/ProfileImage';
 import UserRoleBadge from '@/components/chat/UserRoleBadge';
@@ -43,34 +43,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
     return <UserRoleBadge user={user} size={20} />;
   }, []);
 
-  const getCountryEmoji = useCallback((country?: string): string | null => getCountryFlag(country), []);
-
-  const renderCountryFlag = useCallback(
-    (user: ChatUser) => {
-      const emoji = getCountryEmoji(user.country);
-      const boxStyle: React.CSSProperties = {
-        width: 20,
-        height: 20,
-        borderRadius: 0,
-        display: 'inline-flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        background: 'transparent',
-        border: 'none',
-      };
-
-      if (emoji) {
-        return (
-          <span style={boxStyle} title={user.country}>
-            <span style={{ fontSize: 14, lineHeight: 1 }}>{emoji}</span>
-          </span>
-        );
-      }
-
-      return null;
-    },
-    [getCountryEmoji]
-  );
+  const renderCountryFlag = useCallback((user: ChatUser) => <CountryFlag country={user.country} size={14} />, []);
 
   // تطبيع بيانات المستخدم: إزالة قيم نصية غير صالحة لحقول الألوان/التأثير
   const normalizeUser = useCallback((u: any): ChatUser => {

--- a/client/src/utils/index.ts
+++ b/client/src/utils/index.ts
@@ -72,3 +72,67 @@ export const getCountryFlag = (country?: string): string | null => {
   return null;
 };
 
+// إرجاع كود الدولة ISO-2 من نفس المدخلات المستخدمة أعلاه (إيموجي/اسم/كود)
+export const getCountryIso2 = (country?: string): string | null => {
+  if (!country) return null;
+  const text = country.trim();
+  if (!text) return null;
+
+  // 1) إذا كان في بداية النص علم إيموجي نحوله إلى ISO-2
+  const chars = Array.from(text);
+  const isRegionalIndicator = (cp: number) => cp >= 0x1f1e6 && cp <= 0x1f1ff;
+  if (chars.length >= 2) {
+    const cp0 = chars[0].codePointAt(0) || 0;
+    const cp1 = chars[1].codePointAt(0) || 0;
+    if (isRegionalIndicator(cp0) && isRegionalIndicator(cp1)) {
+      const a = cp0 - 0x1f1e6; // 0..25
+      const b = cp1 - 0x1f1e6; // 0..25
+      if (a >= 0 && a < 26 && b >= 0 && b < 26) {
+        return String.fromCharCode(65 + a) + String.fromCharCode(65 + b);
+      }
+    }
+  }
+
+  // 2) إذا كانت صيغة ISO-2 مباشرة مثل SA/US
+  const isoCandidate = text.replace(/[^A-Za-z]/g, '').toUpperCase();
+  if (isoCandidate.length === 2) return isoCandidate;
+
+  // 3) مطابقة أسماء الدول (عربي/إنجليزي) إلى ISO-2
+  const nameToIso2: Record<string, string> = {
+    'السعودية': 'SA', 'الإمارات': 'AE', 'مصر': 'EG', 'الأردن': 'JO', 'لبنان': 'LB', 'سوريا': 'SY', 'العراق': 'IQ',
+    'الكويت': 'KW', 'قطر': 'QA', 'البحرين': 'BH', 'عمان': 'OM', 'فلسطين': 'PS', 'اليمن': 'YE', 'المغرب': 'MA',
+    'الجزائر': 'DZ', 'تونس': 'TN', 'ليبيا': 'LY', 'السودان': 'SD', 'موريتانيا': 'MR', 'جيبوتي': 'DJ', 'الصومال': 'SO',
+    'جزر القمر': 'KM', 'تركيا': 'TR', 'إيران': 'IR', 'باكستان': 'PK', 'أفغانستان': 'AF', 'الهند': 'IN', 'الصين': 'CN',
+    'اليابان': 'JP', 'كوريا': 'KR', 'بريطانيا': 'GB', 'أمريكا': 'US', 'الولايات المتحدة': 'US', 'كندا': 'CA', 'أستراليا': 'AU',
+    'ألمانيا': 'DE', 'فرنسا': 'FR', 'إيطاليا': 'IT', 'إسبانيا': 'ES', 'البرتغال': 'PT', 'هولندا': 'NL', 'بلجيكا': 'BE',
+    'سويسرا': 'CH', 'النمسا': 'AT', 'الدانمارك': 'DK', 'الدنمارك': 'DK', 'السويد': 'SE', 'النرويج': 'NO', 'فنلندا': 'FI',
+    'روسيا': 'RU', 'بولندا': 'PL', 'التشيك': 'CZ', 'المجر': 'HU', 'اليونان': 'GR', 'بلغاريا': 'BG', 'رومانيا': 'RO',
+    'كرواتيا': 'HR', 'صربيا': 'RS', 'البوسنة': 'BA', 'البرازيل': 'BR', 'الأرجنتين': 'AR', 'المكسيك': 'MX',
+    'saudi arabia': 'SA', 'uae': 'AE', 'united arab emirates': 'AE', 'egypt': 'EG', 'jordan': 'JO', 'lebanon': 'LB',
+    'syria': 'SY', 'iraq': 'IQ', 'kuwait': 'KW', 'qatar': 'QA', 'bahrain': 'BH', 'oman': 'OM', 'palestine': 'PS',
+    'yemen': 'YE', 'morocco': 'MA', 'algeria': 'DZ', 'tunisia': 'TN', 'libya': 'LY', 'sudan': 'SD', 'mauritania': 'MR',
+    'djibouti': 'DJ', 'somalia': 'SO', 'comoros': 'KM', 'turkey': 'TR', 'iran': 'IR', 'pakistan': 'PK', 'afghanistan': 'AF',
+    'india': 'IN', 'china': 'CN', 'japan': 'JP', 'korea': 'KR', 'south korea': 'KR', 'united kingdom': 'GB', 'uk': 'GB',
+    'britain': 'GB', 'usa': 'US', 'united states': 'US', 'canada': 'CA', 'australia': 'AU', 'germany': 'DE', 'france': 'FR',
+    'italy': 'IT', 'spain': 'ES', 'portugal': 'PT', 'netherlands': 'NL', 'belgium': 'BE', 'switzerland': 'CH', 'austria': 'AT',
+    'denmark': 'DK', 'sweden': 'SE', 'norway': 'NO', 'finland': 'FI', 'russia': 'RU', 'poland': 'PL', 'czech': 'CZ', 'hungary': 'HU',
+    'greece': 'GR', 'bulgaria': 'BG', 'romania': 'RO', 'croatia': 'HR', 'serbia': 'RS', 'bosnia': 'BA', 'brazil': 'BR',
+    'argentina': 'AR', 'mexico': 'MX'
+  };
+
+  const normalized = text.toLowerCase().trim();
+  const iso =
+    nameToIso2[normalized] ||
+    nameToIso2[text] ||
+    nameToIso2[normalized.replace(/^.+?\s+/, '')] ||
+    nameToIso2[text.replace(/^.+?\s+/, '')];
+  return iso || null;
+};
+
+// رابط صورة العلم (SVG) عبر flagcdn.com من ISO-2
+export const getCountryFlagUrl = (country?: string): string | null => {
+  const iso = getCountryIso2(country);
+  if (!iso) return null;
+  return `https://flagcdn.com/${iso.toLowerCase()}.svg`;
+};
+


### PR DESCRIPTION
Replace emoji country flags with real flag images in user profiles and lists to enhance visual representation.

---
<a href="https://cursor.com/background-agent?bcId=bc-15e2f588-2908-4703-9994-a8b426fa70fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-15e2f588-2908-4703-9994-a8b426fa70fa">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

