### PR TITLE
Clean trailing whitespace in user list

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -530,7 +530,7 @@ export default function UnifiedSidebar({
           </div>
 
           {/* Users List - Virtualized */}
-          <div className={`bg-background users-list-reset`} style={{ maxHeight: isMobile ? 'calc(100vh - 120px)' : 'calc(100vh - 200px)' }}>
+          <div className={"bg-background users-list-reset flex-1 min-h-0 overflow-hidden flex flex-col"}>
             <div className="bg-primary text-primary-foreground mb-1 mx-0 mt-0 rounded-none">
               <div className="flex items-center justify-between px-3 py-1.5">
                 <div className="flex items-center gap-2 font-bold text-sm">
@@ -559,9 +559,9 @@ export default function UnifiedSidebar({
                 )}
               </div>
             ) : (
-              <div className="px-0" role="list">
+              <div className="px-0 flex-1 min-h-0" role="list">
                 <Virtuoso
-                  style={{ height: isMobile ? 'calc(100vh - 180px)' : 'calc(100vh - 260px)' }}
+                  style={{ height: '100%' }}
                   totalCount={filteredUsers.length}
                   itemContent={(index) => {
                     const user = filteredUsers[index];


### PR DESCRIPTION
Adjust the styling of the users list to remove extra bottom space.

Replaced fixed `calc` height calculations with `flex` properties and `height: 100%` for the `Virtuoso` component to ensure it fills its container, eliminating the reported empty space at the bottom of the user list.

---
<a href="https://cursor.com/background-agent?bcId=bc-541ef68d-8978-4b0e-a06b-e19b2b904d94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-541ef68d-8978-4b0e-a06b-e19b2b904d94">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

