### PR TITLE
Fix profile name display

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2308,11 +2308,10 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center',
-                    maxWidth: '80vw',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap'
+                    textAlign: 'right',
+                    whiteSpace: 'normal',
+                    overflowWrap: 'anywhere',
+                    wordBreak: 'break-word'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2362,11 +2361,10 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center',
-                    maxWidth: '80vw',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap'
+                    textAlign: 'right',
+                    whiteSpace: 'normal',
+                    overflowWrap: 'anywhere',
+                    wordBreak: 'break-word'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2414,11 +2412,10 @@ export default function ProfileModal({
                     textShadow: '0 2px 4px rgba(0,0,0,0.5)',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center',
-                    maxWidth: '80vw',
-                    overflow: 'hidden',
-                    textOverflow: 'ellipsis',
-                    whiteSpace: 'nowrap'
+                    textAlign: 'right',
+                    whiteSpace: 'normal',
+                    overflowWrap: 'anywhere',
+                    wordBreak: 'break-word'
                   }}>
                     <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2308,11 +2308,15 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center'
+                    textAlign: 'center',
+                    maxWidth: '80vw',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
                   }}
                   onClick={() => openEditModal('name')}
                   >
-                    {localUser?.username || 'اسم المستخدم'}
+                    <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>
                 </div>
               </>
@@ -2358,11 +2362,15 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center'
+                    textAlign: 'center',
+                    maxWidth: '80vw',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
                   }}
                   onClick={() => openEditModal('name')}
                   >
-                    {localUser?.username || 'اسم المستخدم'}
+                    <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>
                 </div>
               </>
@@ -2406,9 +2414,13 @@ export default function ProfileModal({
                     textShadow: '0 2px 4px rgba(0,0,0,0.5)',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'center'
+                    textAlign: 'center',
+                    maxWidth: '80vw',
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap'
                   }}>
-                    {localUser?.username || 'اسم المستخدم'}
+                    <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>
                 </div>
               </>


### PR DESCRIPTION
Adjust username display in ProfileModal to allow multi-line wrapping and right-to-left extension for all languages, removing truncation.

The user requested that English names should start from the right and extend to the left, similar to Arabic names, and explicitly asked to remove any text truncation (ellipsis). This change ensures names wrap onto multiple lines if too long, maintaining the desired right-to-left flow for mixed-language content.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c92524a-9816-4397-895f-17470dbcbbf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c92524a-9816-4397-895f-17470dbcbbf7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

