### PR TITLE
Fix room selection redirection bug

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -676,7 +676,9 @@ export function setupRealtime(httpServer: HttpServer): IOServer {
           });
           return;
         }
-        if (now - lastJoinAt < 500) {
+        // اسمح بالتبديل الفوري إلى غرفة مختلفة حتى لو كان الفرق أقل من 500ms
+        const isSwitchingRoom = !!(socket.currentRoom && socket.currentRoom !== roomId);
+        if (!isSwitchingRoom && now - lastJoinAt < 500) {
           return;
         }
         lastJoinAt = now;


### PR DESCRIPTION
Allow immediate room switching in the server's `joinRoom` handler to prevent users from being stuck in the general room.

Previously, the server's `joinRoom` handler had a 500ms cooldown that applied to all room join attempts. This caused a bug where users attempting to join a specific room immediately after connecting (and potentially auto-joining 'general') would have their second `joinRoom` request blocked, leaving them in the 'general' room instead of their chosen one. The fix modifies the cooldown to only apply when re-joining the *same* room, allowing instant switching to a *different* room.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc5a0d66-0ac0-4502-8c24-713ad0bdfca2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc5a0d66-0ac0-4502-8c24-713ad0bdfca2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

