### PR TITLE
Fix text alignment for right-to-left languages

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2308,7 +2308,7 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'right',
+                    textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
                     wordBreak: 'break-word'
@@ -2361,7 +2361,7 @@ export default function ProfileModal({
                     cursor: 'pointer',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'right',
+                    textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
                     wordBreak: 'break-word'
@@ -2412,7 +2412,7 @@ export default function ProfileModal({
                     textShadow: '0 2px 4px rgba(0,0,0,0.5)',
                     direction: 'auto',
                     unicodeBidi: 'plaintext',
-                    textAlign: 'right',
+                    textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
                     wordBreak: 'break-word'


### PR DESCRIPTION
Update `textAlign` to `center` for user names in `ProfileModal.tsx` to correctly display English names while respecting their natural text direction.

---
<a href="https://cursor.com/background-agent?bcId=bc-d7036381-3702-4ab0-9556-891a85c67aa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d7036381-3702-4ab0-9556-891a85c67aa5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

