### PR TITLE
Fix long name display on profile

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -512,8 +512,9 @@ export default function MessageArea({
                       )}
                       <button
                         onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
-                        className="font-semibold hover:underline transition-colors duration-200 truncate"
+                        className="font-semibold hover:underline transition-colors duration-200 truncate max-w-[120px] flex-shrink-0"
                         style={{ color: getFinalUsernameColor(message.sender) }}
+                        title={message.sender?.username}
                       >
                         {message.sender?.username}
                       </button>

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2311,7 +2311,9 @@ export default function ProfileModal({
                     textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    wordBreak: 'break-word',
+                    maxWidth: '200px',
+                    lineHeight: '1.2'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2364,7 +2366,9 @@ export default function ProfileModal({
                     textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    wordBreak: 'break-word',
+                    maxWidth: '200px',
+                    lineHeight: '1.2'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2415,7 +2419,9 @@ export default function ProfileModal({
                     textAlign: 'center',
                     whiteSpace: 'normal',
                     overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    wordBreak: 'break-word',
+                    maxWidth: '200px',
+                    lineHeight: '1.2'
                   }}>
                     <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -482,7 +482,7 @@ export default function UnifiedSidebar({
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2">
                       <span
-                        className="text-base font-medium transition-colors duration-300"
+                        className="text-base font-medium transition-colors duration-300 truncate max-w-[120px]"
                         style={{
                           color: getFinalUsernameColor(user),
                         }}
@@ -699,7 +699,7 @@ export default function UnifiedSidebar({
                           <div className="flex-1">
                             <div className="flex items-center gap-2">
                               <span
-                                className="font-medium text-sm cursor-pointer hover:underline"
+                                className="font-medium text-sm cursor-pointer hover:underline truncate max-w-[100px]"
                                 style={{ color: post.usernameColor || 'inherit' }}
                                 onClick={(e) => {
                                   const targetUser: ChatUser = {
@@ -713,7 +713,7 @@ export default function UnifiedSidebar({
                                   } as ChatUser;
                                   handleUserClick(e as any, targetUser);
                                 }}
-                                title="عرض خيارات المستخدم"
+                                title={post.username}
                               >
                                 {post.username}
                               </span>


### PR DESCRIPTION
Adjust username display styling across MessageArea, ProfileModal, and UserSidebarWithWalls to prevent long names from overlapping with profile images and ensure proper truncation with tooltips.

---
<a href="https://cursor.com/background-agent?bcId=bc-8370591a-2170-447e-b1bd-dabbcb53ba0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8370591a-2170-447e-b1bd-dabbcb53ba0a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

