### PR TITLE
Adjust profile picture height

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1453,7 +1453,7 @@ export default function ProfileModal({
 
         .profile-cover {
           position: relative;
-          height: 250px;
+          height: 220px;
           background-size: cover;
           background-position: center;
           background-repeat: no-repeat;
@@ -1572,7 +1572,7 @@ export default function ProfileModal({
         }
 
         .profile-body {
-          padding: 20px 20px 16px;
+          padding: 20px 20px 10px;
         }
 
         .profile-info {
@@ -2198,7 +2198,7 @@ export default function ProfileModal({
       <div className="fixed inset-0 z-50 bg-black/80 backdrop-blur-sm" onClick={onClose} />
 
       {/* Main Modal */}
-      <div className="fixed inset-0 z-50 flex items-start justify-center pt-8 pb-4 px-4 overflow-y-auto">
+      <div className="fixed inset-0 z-50 flex items-start justify-center pt-6 pb-2 px-4 overflow-y-auto">
         <div
           className={`profile-card ${selectedEffect}`}
           style={{


### PR DESCRIPTION
Reduce the profile modal's overall length by decreasing the cover height and adjusting vertical padding.

---
<a href="https://cursor.com/background-agent?bcId=bc-7d86eb20-ff8c-4413-87c3-9763117e2f62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7d86eb20-ff8c-4413-87c3-9763117e2f62">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

