### PR TITLE
Adjust profile text overflow to the left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2283,7 +2283,10 @@ export default function ProfileModal({
                   alignItems: 'center',
                   gap: '1px', /* تقليل الفراغ بين اللقب والاسم */
                   zIndex: 3,
-                  textAlign: 'center'
+                  textAlign: 'center',
+                  maxWidth: 'calc(100% - 180px)',
+                  padding: '0 12px',
+                  boxSizing: 'border-box'
                 }}>
                   {/* الرتبة فوق الاسم */}
                   {(localUser?.userType === 'owner' || localUser?.userType === 'admin' || localUser?.userType === 'moderator') && (
@@ -2310,8 +2313,9 @@ export default function ProfileModal({
                     unicodeBidi: 'plaintext',
                     textAlign: 'center',
                     whiteSpace: 'normal',
-                    overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    overflowWrap: 'break-word',
+                    wordBreak: 'keep-all',
+                    hyphens: 'none'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2338,7 +2342,10 @@ export default function ProfileModal({
                   alignItems: 'center',
                   gap: '1px',
                   zIndex: 12,
-                  textAlign: 'center'
+                  textAlign: 'center',
+                  maxWidth: 'calc(100% - 180px)',
+                  padding: '0 12px',
+                  boxSizing: 'border-box'
                 }}>
                   {(localUser?.userType === 'owner' || localUser?.userType === 'admin' || localUser?.userType === 'moderator') && (
                     <div style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
@@ -2363,8 +2370,9 @@ export default function ProfileModal({
                     unicodeBidi: 'plaintext',
                     textAlign: 'center',
                     whiteSpace: 'normal',
-                    overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    overflowWrap: 'break-word',
+                    wordBreak: 'keep-all',
+                    hyphens: 'none'
                   }}
                   onClick={() => openEditModal('name')}
                   >
@@ -2388,7 +2396,10 @@ export default function ProfileModal({
                   gap: '1px', /* تقليل الفراغ بين اللقب والاسم */
                   zIndex: 12,
                   pointerEvents: 'none',
-                  textAlign: 'center'
+                  textAlign: 'center',
+                  maxWidth: 'calc(100% - 180px)',
+                  padding: '0 12px',
+                  boxSizing: 'border-box'
                 }}>
                   {/* الرتبة فوق الاسم */}
                   {(localUser?.userType === 'owner' || localUser?.userType === 'admin' || localUser?.userType === 'moderator') && (
@@ -2414,8 +2425,9 @@ export default function ProfileModal({
                     unicodeBidi: 'plaintext',
                     textAlign: 'center',
                     whiteSpace: 'normal',
-                    overflowWrap: 'anywhere',
-                    wordBreak: 'break-word'
+                    overflowWrap: 'break-word',
+                    wordBreak: 'keep-all',
+                    hyphens: 'none'
                   }}>
                     <bdi>{localUser?.username || 'اسم المستخدم'}</bdi>
                   </h3>


### PR DESCRIPTION
Adjust profile name styling in the profile modal to prevent long names from overlapping the avatar and ensure they wrap correctly without being cut.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbf21cb2-a425-4ba8-9497-36d5d46b9fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbf21cb2-a425-4ba8-9497-36d5d46b9fad">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

