### PR TITLE
Adjust profile name position left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2282,7 +2282,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px', /* إنزال المجموعة (اللقب والاسم) أقرب للأسفل */
                   left: '50%',
-                  transform: 'translateX(-50%)',
+                  transform: 'translateX(calc(-50% - 12px))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2341,7 +2341,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px',
                   left: '50%',
-                  transform: 'translateX(-50%)',
+                  transform: 'translateX(calc(-50% - 12px))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2394,7 +2394,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '60px', /* رفع الاسم فوق شريط الأزرار */
                   left: '50%',
-                  transform: 'translateX(-50%)',
+                  transform: 'translateX(calc(-50% - 12px))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',


### PR DESCRIPTION
Adjust the horizontal position of the user's name and title in the profile modal to shift them slightly to the left.

---
<a href="https://cursor.com/background-agent?bcId=bc-3ae21386-673c-47b5-a681-c103991c53b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3ae21386-673c-47b5-a681-c103991c53b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

