### PR TITLE
Fix mobile wall tab scrolling

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -603,7 +603,7 @@ export default function UnifiedSidebar({
                 const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
                 setIsAtBottomSidebarWall(atBottom);
               }}
-              className="flex-1 overflow-y-auto px-2 pb-4 cursor-grab"
+              className="flex-1 overflow-y-auto touch-scroll px-2 pb-4 cursor-grab"
             >
               {/* Post Creation */}
               {currentUser && currentUser.userType !== 'guest' && (

--- a/client/src/components/chat/WallPanel.tsx
+++ b/client/src/components/chat/WallPanel.tsx
@@ -515,7 +515,7 @@ export default function WallPanel({ isOpen, onClose, currentUser }: WallPanelPro
                 <div
                   ref={panelScrollRef}
                   onScroll={handleWallScroll}
-                  className="h-full overflow-y-auto space-y-4 pr-2 pb-24 cursor-grab"
+                  className="h-full overflow-y-auto touch-scroll space-y-4 pr-2 pb-24 cursor-grab"
                 >
                   <WallPostList
                     posts={posts}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1183,6 +1183,13 @@ body.ltr {
   touch-action: auto;
 }
 
+/* Mobile touch scroll helper - ensures native touch scrolling in scrollables */
+.touch-scroll {
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: auto !important;
+  touch-action: pan-y !important;
+}
+
 /* Chat layout improvements - تحسينات خاصة بتخطيط الدردشة */
 .chat-main-container {
   height: calc(100vh - 160px);


### PR DESCRIPTION
Add `touch-scroll` class to wall containers to enable native mobile scrolling.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2c5a554-0eb7-48f1-b561-61537903d8b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2c5a554-0eb7-48f1-b561-61537903d8b9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

