### PR TITLE
Fix member and visitor profile colors to match bot

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -57,6 +57,17 @@ export default function ProfileModal({
   const [selectedTheme, setSelectedTheme] = useState(user?.profileBackgroundColor || '');
   const [selectedEffect, setSelectedEffect] = useState(user?.profileEffect || 'none');
 
+  // توحيد لون خلفية الملف الشخصي للأعضاء والزوار ليطابق لون البوت فقط داخل نافذة البروفايل
+  const isMemberOrGuest =
+    (localUser?.userType === 'member' || localUser?.userType === 'guest');
+  const forcedBotColor = '#2a2a2a';
+  const resolvedProfileColorForCard = isMemberOrGuest
+    ? forcedBotColor
+    : (localUser?.profileBackgroundColor || '');
+  const computedCardGradient =
+    buildProfileBackgroundGradient(resolvedProfileColorForCard) ||
+    'linear-gradient(135deg, #1a1a1a, #2d2d2d)';
+
   // متغيرات نظام إرسال النقاط
   const [sendingPoints, setSendingPoints] = useState(false);
   const [pointsToSend, setPointsToSend] = useState('');
@@ -2204,10 +2215,9 @@ export default function ProfileModal({
         <div
           className={`profile-card ${selectedEffect}`}
           style={{
-            background: localUser?.profileBackgroundColor
-              ? buildProfileBackgroundGradient(localUser.profileBackgroundColor)
-              : 'linear-gradient(135deg, #1a1a1a, #2d2d2d)',
+            background: computedCardGradient,
             backgroundBlendMode: 'normal',
+            ['--card-bg' as any]: computedCardGradient,
           }}
         >
           {/* Close Button */}


### PR DESCRIPTION
Unify member and guest profile background color with the bot's color (`#2a2a2a`) in the profile modal to resolve a brown color discrepancy.

This change specifically targets the `ProfileModal.tsx` component, ensuring that only the profile view for members and guests displays the bot's background color, without affecting other parts of the application.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e5f79bd-55b4-499a-b968-a373c92d8668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5e5f79bd-55b4-499a-b968-a373c92d8668">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

