### PR TITLE
Fix user status display on profiles

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2505,7 +2505,7 @@ export default function ProfileModal({
                 onClick={() => localUser?.id === currentUser?.id && openEditModal('status')}
                 style={{ cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default' }}
               >
-                {localUser?.status || 'اضغط لإضافة حالة'}
+                {localUser?.status || (localUser?.id === currentUser?.id ? 'اضغط لإضافة حالة' : '')}
               </small>
             </div>
 


### PR DESCRIPTION
Restrict the 'اضغط لإضافة حالة' placeholder in the profile modal to only show for the profile owner.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5ba8b8c-20c0-43e5-9ba5-42bd73c9618a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5ba8b8c-20c0-43e5-9ba5-42bd73c9618a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

