### PR TITLE
Fix bot message clearing and status handling

### DIFF
--- a/client/src/components/chat/bots/BotsManagement.tsx
+++ b/client/src/components/chat/bots/BotsManagement.tsx
@@ -78,7 +78,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
   const [newBot, setNewBot] = useState({
     username: '',
     password: '',
-    status: 'بوت نشط',
+    status: '',
     bio: 'أنا بوت آلي',
     botType: 'system' as 'system' | 'chat' | 'moderator',
     usernameColor: '#00FF00',
@@ -194,7 +194,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
       setNewBot({
         username: '',
         password: '',
-        status: 'بوت نشط',
+        status: '',
         bio: 'أنا بوت آلي',
         botType: 'system',
         usernameColor: '#00FF00',
@@ -484,7 +484,9 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
                               <Badge className="bg-gray-100 text-gray-800">معطل</Badge>
                             )}
                           </div>
-                          <span className="text-xs text-gray-500">{bot.status}</span>
+                          {bot.status ? (
+                            <span className="text-xs text-gray-500">{bot.status}</span>
+                          ) : null}
                         </div>
                       </div>
                     </TableCell>

--- a/migrations/add-bots-table.sql
+++ b/migrations/add-bots-table.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS bots (
     profile_image TEXT,
     profile_banner TEXT,
     profile_background_color TEXT DEFAULT '#2a2a2a',
-    status TEXT DEFAULT 'بوت نشط',
+    status TEXT,
     gender TEXT DEFAULT 'غير محدد',
     country TEXT DEFAULT 'غير محدد',
     relation TEXT DEFAULT 'غير محدد',

--- a/server/database-adapter.ts
+++ b/server/database-adapter.ts
@@ -326,7 +326,7 @@ export async function ensureBotsTable(): Promise<void> {
           profile_image TEXT,
           profile_banner TEXT,
           profile_background_color TEXT DEFAULT '#2a2a2a',
-          status TEXT DEFAULT 'بوت نشط',
+          status TEXT,
           gender TEXT DEFAULT 'غير محدد',
           country TEXT DEFAULT 'غير محدد',
           relation TEXT DEFAULT 'غير محدد',

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4282,6 +4282,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       };
       const [newBot] = await db.insert(bots).values({
         ...body,
+        // إذا لم تُرسل حالة، اجعلها فارغة
+        status: typeof body.status === 'string' ? body.status : null,
         // حقول بسيطة تُخزن مباشرة
         relation: typeof relation === 'string' ? relation : body.relation,
         country: typeof country === 'string' ? country : body.country,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -575,7 +575,7 @@ export const bots = pgTable('bots', {
   profileImage: text('profile_image'),
   profileBanner: text('profile_banner'),
   profileBackgroundColor: text('profile_background_color').default('#2a2a2a'),
-  status: text('status').default('بوت نشط'),
+  status: text('status'),
   gender: text('gender').default('غير محدد'),
   country: text('country').default('غير محدد'),
   relation: text('relation').default('غير محدد'),


### PR DESCRIPTION
Allow bot status to be optional and empty by default by removing the hardcoded 'بوت نشط' status.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3564917-9825-430f-9be1-13b4fa2f82b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3564917-9825-430f-9be1-13b4fa2f82b6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

