### PR TITLE
Manage bot profile visibility

### DIFF
--- a/client/src/components/chat/bots/BotsManagement.tsx
+++ b/client/src/components/chat/bots/BotsManagement.tsx
@@ -78,7 +78,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
   const [newBot, setNewBot] = useState({
     username: '',
     password: '',
-    status: 'بوت نشط',
+    status: '',
     bio: 'أنا بوت آلي',
     botType: 'system' as 'system' | 'chat' | 'moderator',
     usernameColor: '#00FF00',
@@ -194,7 +194,7 @@ export default function BotsManagement({ currentUser }: BotsManagementProps) {
       setNewBot({
         username: '',
         password: '',
-        status: 'بوت نشط',
+        status: '',
         bio: 'أنا بوت آلي',
         botType: 'system',
         usernameColor: '#00FF00',

--- a/migrations/2025-09-06-remove-bot-active-status-default.sql
+++ b/migrations/2025-09-06-remove-bot-active-status-default.sql
@@ -1,0 +1,5 @@
+-- Remove default for bots.status and clear existing textual defaults
+ALTER TABLE IF EXISTS bots ALTER COLUMN status DROP DEFAULT;
+
+-- Normalize existing rows: set status to NULL where it equals the old default
+UPDATE bots SET status = NULL WHERE status = 'بوت نشط';

--- a/migrations/add-bots-table.sql
+++ b/migrations/add-bots-table.sql
@@ -8,7 +8,7 @@ CREATE TABLE IF NOT EXISTS bots (
     profile_image TEXT,
     profile_banner TEXT,
     profile_background_color TEXT DEFAULT '#2a2a2a',
-    status TEXT DEFAULT 'بوت نشط',
+    status TEXT,
     gender TEXT DEFAULT 'غير محدد',
     country TEXT DEFAULT 'غير محدد',
     relation TEXT DEFAULT 'غير محدد',

--- a/server/database-adapter.ts
+++ b/server/database-adapter.ts
@@ -326,7 +326,7 @@ export async function ensureBotsTable(): Promise<void> {
           profile_image TEXT,
           profile_banner TEXT,
           profile_background_color TEXT DEFAULT '#2a2a2a',
-          status TEXT DEFAULT 'بوت نشط',
+          status TEXT,
           gender TEXT DEFAULT 'غير محدد',
           country TEXT DEFAULT 'غير محدد',
           relation TEXT DEFAULT 'غير محدد',

--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -967,7 +967,7 @@ async function loadActiveBots() {
       console.log(`✓ تم تحميل البوت: ${bot.username} في الغرفة ${bot.currentRoom}`);
     }
     
-    console.log(`✓ تم تحميل ${activeBots.length} بوت نشط`);
+    console.log(`✓ تم تحميل عدد البوتات: ${activeBots.length}`);
   } catch (error) {
     console.error('خطأ في تحميل البوتات:', error);
   }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -575,7 +575,7 @@ export const bots = pgTable('bots', {
   profileImage: text('profile_image'),
   profileBanner: text('profile_banner'),
   profileBackgroundColor: text('profile_background_color').default('#2a2a2a'),
-  status: text('status').default('بوت نشط'),
+  status: text('status'),
   gender: text('gender').default('غير محدد'),
   country: text('country').default('غير محدد'),
   relation: text('relation').default('غير محدد'),
@@ -591,7 +591,7 @@ export const bots = pgTable('bots', {
   createdBy: integer('created_by').references(() => users.id), // من قام بإنشاء البوت
   createdAt: timestamp('created_at').defaultNow(),
   lastActivity: timestamp('last_activity').defaultNow(),
-  isActive: boolean('is_active').default(true), // هل البوت نشط أم معطل
+  isActive: boolean('is_active').default(true), // حالة التفعيل للبوت
   botType: text('bot_type').default('system'), // نوع البوت: system, chat, moderator
   settings: jsonb('settings').default({}), // إعدادات إضافية للبوت
 });


### PR DESCRIPTION
Remove the default 'بوت نشط' status for bots to ensure status is only displayed when explicitly set.

---
<a href="https://cursor.com/background-agent?bcId=bc-a46ba4df-f3f4-4c47-a12c-3d78827d2f2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a46ba4df-f3f4-4c47-a12c-3d78827d2f2f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

