### PR TITLE
Investigate and fix chat lock tab

### DIFF
--- a/client/src/components/chat/BroadcastRoomInterface.tsx
+++ b/client/src/components/chat/BroadcastRoomInterface.tsx
@@ -1025,6 +1025,8 @@ export default function BroadcastRoomInterface({
             onlineUsers={onlineUsers}
             currentRoomName={room?.name || 'غرفة البث'}
             currentRoomId={room?.id}
+            chatLockAll={room?.chatLockAll}
+            chatLockVisitors={room?.chatLockVisitors}
           />
         </div>
       </div>

--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -98,6 +98,9 @@ export interface Room {
   speakers?: string | any[];
   micQueue?: string | any[];
   icon?: string | null;
+  // Chat lock settings (PG only)
+  chatLockAll?: boolean;
+  chatLockVisitors?: boolean;
 }
 
 export interface Story {
@@ -1657,6 +1660,11 @@ export class DatabaseService {
           (allowed as any).isLocked = (updates as any).isLocked;
         if (typeof (updates as any).hostId !== 'undefined')
           allowed.hostId = (updates as any).hostId;
+        // Chat lock settings
+        if (typeof (updates as any).chatLockAll === 'boolean')
+          (allowed as any).chatLockAll = (updates as any).chatLockAll;
+        if (typeof (updates as any).chatLockVisitors === 'boolean')
+          (allowed as any).chatLockVisitors = (updates as any).chatLockVisitors;
         if (Object.keys(allowed).length === 0) {
           // Nothing to update
           const row = await this.getRoomById(roomId);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -187,6 +187,9 @@ export const rooms = pgTable('rooms', {
   isLocked: boolean('is_locked').default(false),
   isBroadcast: boolean('is_broadcast').default(false),
   hostId: integer('host_id').references(() => users.id),
+  // Chat lock settings
+  chatLockAll: boolean('chat_lock_all').default(false),
+  chatLockVisitors: boolean('chat_lock_visitors').default(false),
   speakers: text('speakers').default('[]'), // JSON string
   micQueue: text('mic_queue').default('[]'), // JSON string
   slug: text('slug'),


### PR DESCRIPTION
Enable the "Chat Lock" tab functionality by integrating chat lock settings into the database schema and service.

The "Chat Lock" tab was previously non-functional because the `chat_lock_all` and `chat_lock_visitors` columns were missing from the shared database schema and were not handled by the `updateRoomById` method in the database service. This PR resolves the issue by adding these fields to the schema, extending the `Room` interface, and enabling their proper persistence and retrieval, allowing the existing frontend and backend logic to manage chat locking.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2099263-e3c0-43b7-8dd6-518d7e955150">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2099263-e3c0-43b7-8dd6-518d7e955150">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

