### PR TITLE
Handle room by id query error

### DIFF
--- a/scripts/fix-rooms-columns.ts
+++ b/scripts/fix-rooms-columns.ts
@@ -1,0 +1,69 @@
+import postgres from 'postgres';
+
+async function main() {
+  const databaseUrl = process.env.DATABASE_URL;
+  if (!databaseUrl) {
+    console.error('❌ DATABASE_URL is not set');
+    process.exit(1);
+  }
+
+  const sql = postgres(databaseUrl, {
+    ssl: databaseUrl.includes('localhost') ? false : 'require',
+    max: 1,
+  });
+
+  try {
+    console.log('🔧 Ensuring rooms columns...');
+
+    await sql.unsafe(`CREATE EXTENSION IF NOT EXISTS citext;`);
+
+    await sql.unsafe(`
+      ALTER TABLE IF EXISTS rooms
+        ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMPTZ;
+    `);
+
+    await sql.unsafe(`
+      ALTER TABLE IF EXISTS rooms
+        ADD COLUMN IF NOT EXISTS last_message_at TIMESTAMPTZ;
+    `);
+
+    await sql.unsafe(`
+      ALTER TABLE IF EXISTS rooms
+        ADD COLUMN IF NOT EXISTS slug CITEXT;
+    `);
+
+    await sql.unsafe(`
+      ALTER TABLE IF EXISTS rooms
+        ADD COLUMN IF NOT EXISTS is_locked BOOLEAN DEFAULT FALSE;
+    `);
+
+    await sql.unsafe(`
+      ALTER TABLE IF NOT EXISTS rooms
+        ADD COLUMN IF NOT EXISTS chat_lock_all BOOLEAN DEFAULT FALSE;
+    `);
+
+    await sql.unsafe(`
+      ALTER TABLE IF NOT EXISTS rooms
+        ADD COLUMN IF NOT EXISTS chat_lock_visitors BOOLEAN DEFAULT FALSE;
+    `);
+
+    await sql.unsafe(`
+      CREATE UNIQUE INDEX IF NOT EXISTS uniq_rooms_slug_active
+        ON rooms (slug)
+        WHERE deleted_at IS NULL AND slug IS NOT NULL;
+    `);
+
+    await sql.unsafe(`
+      CREATE INDEX IF NOT EXISTS idx_rooms_active ON rooms (deleted_at) WHERE deleted_at IS NULL;
+    `);
+
+    console.log('✅ Rooms columns ensured.');
+  } catch (e: any) {
+    console.error('❌ Failed ensuring rooms columns:', e?.message || e);
+    process.exit(1);
+  } finally {
+    await sql.end();
+  }
+}
+
+main();


### PR DESCRIPTION
Add missing columns and indexes to the `rooms` table to resolve Drizzle query errors.

The Drizzle query was failing because the `rooms` table in the database was missing several columns (e.g., `deleted_at`, `is_locked`, `chat_lock_all`, `chat_lock_visitors`, `last_message_at`, `slug`) that the application expected. This PR introduces a database safety net at startup and a manual fixer script to ensure these columns and necessary indexes are present, preventing future query failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f69f15a-0ecb-4f1b-b0bd-5d92386ebb4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9f69f15a-0ecb-4f1b-b0bd-5d92386ebb4a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

