### PR TITLE
Adjust profile elements to the left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2292,7 +2292,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px', /* إنزال المجموعة (اللقب والاسم) أقرب للأسفل */
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 3cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2351,7 +2351,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px',
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 3cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2404,7 +2404,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '60px', /* رفع الاسم فوق شريط الأزرار */
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 3cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2500,7 +2500,7 @@ export default function ProfileModal({
 
           {/* Profile Body - exact match to original */}
           <div className="profile-body">
-            <div className="profile-info">
+            <div className="profile-info" style={{ transform: 'translateX(-3cm)' }}>
               <small
                 onClick={() => localUser?.id === currentUser?.id && openEditModal('status')}
                 style={{ cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default' }}


### PR DESCRIPTION
Shifted user name, supervisor badge, and status left by 3cm in the profile modal to fulfill a user request for visual adjustment.

---
<a href="https://cursor.com/background-agent?bcId=bc-467fe7a4-1732-4451-8367-04c7d7f2a662">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-467fe7a4-1732-4451-8367-04c7d7f2a662">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

