### PR TITLE
Adjust profile elements left

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2292,7 +2292,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px', /* إنزال المجموعة (اللقب والاسم) أقرب للأسفل */
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 2cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2351,7 +2351,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '38px',
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 2cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2404,7 +2404,7 @@ export default function ProfileModal({
                   position: 'absolute',
                   bottom: '60px', /* رفع الاسم فوق شريط الأزرار */
                   left: '50%',
-                  transform: 'translateX(calc(-50% - 12px))',
+                  transform: 'translateX(calc(-50% - 12px - 2cm))',
                   display: 'flex',
                   flexDirection: 'column',
                   alignItems: 'center',
@@ -2503,7 +2503,7 @@ export default function ProfileModal({
             <div className="profile-info">
               <small
                 onClick={() => localUser?.id === currentUser?.id && openEditModal('status')}
-                style={{ cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default' }}
+                style={{ cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default', display: 'inline-block', transform: 'translateX(-2cm)' }}
               >
                 {localUser?.status || (localUser?.id === currentUser?.id ? 'اضغط لإضافة حالة' : '')}
               </small>


### PR DESCRIPTION
Shift profile name, supervisor logo, and status 2cm to the left in `ProfileModal.tsx` as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-d263c11c-f3ba-4f40-9154-e90e00d7ab8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d263c11c-f3ba-4f40-9154-e90e00d7ab8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

