### PR TITLE
Investigate intermittent room connection failures

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -79,13 +79,19 @@ function attachCoreListeners(socket: Socket) {
         reconnect: isReconnect,
       });
 
+      // 🔧 إصلاح: انتظار المصادقة قبل الانضمام للغرفة
       const joinRoomId = session.roomId;
       if (joinRoomId && joinRoomId !== 'public' && joinRoomId !== 'friends') {
-        socket.emit('joinRoom', {
-          roomId: joinRoomId,
-          userId: session.userId,
-          username: session.username,
-        });
+        // انتظار قصير للتأكد من اكتمال المصادقة
+        setTimeout(() => {
+          if (socket.connected && socket.id) {
+            socket.emit('joinRoom', {
+              roomId: joinRoomId,
+              userId: session.userId,
+              username: session.username,
+            });
+          }
+        }, 1000); // انتظار ثانية واحدة
       }
     } catch {}
   };
@@ -142,10 +148,10 @@ export function getSocket(): Socket {
     autoConnect: false,
     reconnection: true,
     reconnectionAttempts: Infinity, // محاولات غير محدودة
-    reconnectionDelay: 3000,
-    reconnectionDelayMax: 30000, // زيادة الحد الأقصى
-    randomizationFactor: 0.5,
-    timeout: 30000, // زيادة timeout
+    reconnectionDelay: 1000, // 🔧 تقليل تأخير إعادة الاتصال
+    reconnectionDelayMax: 10000, // 🔧 تقليل الحد الأقصى
+    randomizationFactor: 0.2, // 🔧 تقليل العشوائية
+    timeout: 10000, // 🔧 تقليل timeout للاستجابة الأسرع
     forceNew: true,
     withCredentials: true,
     auth: { deviceId },

--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -662,6 +662,17 @@ export function setupRealtime(httpServer: HttpServer): IOServer {
         socket.emit('message', { type: 'error', message: 'يجب تسجيل الدخول أولاً' });
         return;
       }
+      
+      // 🔧 إصلاح: التأكد من اكتمال المصادقة
+      if (!isAuthenticated) {
+        // انتظار قصير للمصادقة
+        setTimeout(() => {
+          if (isAuthenticated && socket.userId) {
+            socket.emit('joinRoom', data); // إعادة المحاولة
+          }
+        }, 500);
+        return;
+      }
       const roomId = data && data.roomId ? String(data.roomId) : 'general';
       const username = socket.username || `User#${socket.userId}`;
       try {
@@ -675,7 +686,7 @@ export function setupRealtime(httpServer: HttpServer): IOServer {
           });
           return;
         }
-        if (now - lastJoinAt < 500) {
+        if (now - lastJoinAt < 200) { // 🔧 تقليل من 500ms إلى 200ms
           return;
         }
         lastJoinAt = now;


### PR DESCRIPTION
Fix race condition in room joining by ensuring authentication completes before sending join requests and optimizing socket connection settings.

The issue stemmed from a race condition where `joinRoom` requests could be sent before user authentication was fully established, leading to connection loss or failed room entry. Server-side cooldowns and client-side socket configuration also exacerbated the problem. These changes introduce delays and checks to synchronize the authentication and joining process, alongside more responsive connection settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ecd2942-cc00-49de-a014-4caada20d25d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ecd2942-cc00-49de-a014-4caada20d25d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

