### PR TITLE
Fix refresh and profile page errors

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1268,6 +1268,67 @@ li > * > div.effect-crystal {
   background-blend-mode: normal;
 }
 
+/* كلاسات التأثيرات للقائمة - بدون أنيميشن لتجنب الاهتزاز */
+.user-list-effect-electric {
+  box-shadow: 0 0 8px rgba(0, 191, 255, 0.3);
+  border-left: 2px solid rgba(0, 191, 255, 0.5);
+}
+
+.user-list-effect-magnetic {
+  box-shadow: 0 0 8px rgba(255, 20, 147, 0.3);
+  border-left: 2px solid rgba(255, 20, 147, 0.5);
+}
+
+.user-list-effect-pulse {
+  box-shadow: 0 0 8px rgba(138, 43, 226, 0.3);
+  border-left: 2px solid rgba(138, 43, 226, 0.5);
+}
+
+.user-list-effect-glow {
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.3);
+  border-left: 2px solid rgba(255, 215, 0, 0.5);
+}
+
+.user-list-effect-water {
+  box-shadow: 0 0 8px rgba(0, 150, 255, 0.3);
+  border-left: 2px solid rgba(0, 150, 255, 0.5);
+}
+
+.user-list-effect-aurora {
+  box-shadow: 0 0 8px rgba(0, 255, 127, 0.3);
+  border-left: 2px solid rgba(0, 255, 127, 0.5);
+}
+
+.user-list-effect-neon {
+  box-shadow: 0 0 8px rgba(255, 20, 147, 0.3);
+  border-left: 2px solid rgba(255, 20, 147, 0.5);
+}
+
+.user-list-effect-fire {
+  box-shadow: 0 0 8px rgba(255, 69, 0, 0.3);
+  border-left: 2px solid rgba(255, 69, 0, 0.5);
+}
+
+.user-list-effect-ice {
+  box-shadow: 0 0 8px rgba(135, 206, 235, 0.3);
+  border-left: 2px solid rgba(135, 206, 235, 0.5);
+}
+
+.user-list-effect-rainbow {
+  box-shadow: 0 0 8px rgba(236, 72, 153, 0.3);
+  border-left: 2px solid rgba(236, 72, 153, 0.5);
+}
+
+.user-list-effect-shadow {
+  box-shadow: 0 0 8px rgba(0, 0, 0, 0.5);
+  border-left: 2px solid rgba(0, 0, 0, 0.7);
+}
+
+.user-list-effect-crystal {
+  box-shadow: 0 0 8px rgba(230, 230, 250, 0.3);
+  border-left: 2px solid rgba(230, 230, 250, 0.5);
+}
+
 /* تأثير hover محسّن للصناديق بألوان مخصصة */
 .has-custom-bg:hover {
   filter: none;

--- a/client/src/utils/themeUtils.ts
+++ b/client/src/utils/themeUtils.ts
@@ -237,9 +237,10 @@ export const getUserListItemClasses = (user: any): string => {
     return '';
   }
 
-  // إضافة كلاس التأثير إذا وجد (للمشرفين فقط)
+  // إضافة كلاس التأثير إذا وجد (للمشرفين فقط) - لكن بدون الأنيميشن
   if (user?.profileEffect && user.profileEffect !== 'none') {
-    classes.push(user.profileEffect);
+    // إضافة كلاس خاص للقائمة بدلاً من التأثير المباشر لتجنب الاهتزاز
+    classes.push(`user-list-${user.profileEffect}`);
   }
 
   // إضافة كلاس خاص إذا كان هناك لون خلفية (للمشرفين فقط)


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Prevent user list items from shaking by applying visual-only effects instead of animated profile effects.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `user.profileEffect` classes, such as `effect-magnetic` and `effect-pulse`, include animations designed for individual profile displays. When these were directly applied to user items in a list, they caused an unwanted continuous "shaking" or "vibrating" effect. This PR introduces specific `user-list-effect-*` classes with static visual styles (shadows, borders) to maintain the intended aesthetic without the disruptive animations.

---
<a href="https://cursor.com/background-agent?bcId=bc-741585f2-d5f6-4a4d-a5bb-881ab3847ebe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-741585f2-d5f6-4a4d-a5bb-881ab3847ebe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

