### PR TITLE
Fix refresh and session persistence

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -17,13 +17,13 @@ export function saveSession(partial: Partial<StoredSession>) {
   try {
     const existing = getSession();
     const merged: StoredSession = { ...existing, ...partial };
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(merged));
   } catch {}
 }
 
 export function getSession(): StoredSession {
   try {
-    const raw = sessionStorage.getItem(STORAGE_KEY);
+    const raw = localStorage.getItem(STORAGE_KEY);
     if (!raw) return {};
     return JSON.parse(raw) as StoredSession;
   } catch {
@@ -33,7 +33,7 @@ export function getSession(): StoredSession {
 
 export function clearSession() {
   try {
-    sessionStorage.removeItem(STORAGE_KEY);
+    localStorage.removeItem(STORAGE_KEY);
   } catch {}
   // إعادة تعيين Socket instance عند مسح الجلسة
   if (socketInstance) {
@@ -78,15 +78,6 @@ function attachCoreListeners(socket: Socket) {
         token: session.token,
         reconnect: isReconnect,
       });
-
-      const joinRoomId = session.roomId;
-      if (joinRoomId && joinRoomId !== 'public' && joinRoomId !== 'friends') {
-        socket.emit('joinRoom', {
-          roomId: joinRoomId,
-          userId: session.userId,
-          username: session.username,
-        });
-      }
     } catch {}
   };
 

--- a/client/src/pages/CountryChat.tsx
+++ b/client/src/pages/CountryChat.tsx
@@ -50,30 +50,38 @@ export default function CountryChat() {
     try {
       const session = getSession();
       const savedUserId = session?.userId;
-      if (!savedUserId) {
-        setIsRestoring(false);
-        return;
+      const proceedWithUser = (user: any) => {
+        if (!user || !user.id || !user.username) return;
+        chat.connect(user);
+        setShowWelcome(false);
+        const roomId = session?.roomId && session.roomId !== 'public' && session.roomId !== 'friends'
+          ? session.roomId
+          : null;
+        if (roomId) {
+          setSelectedRoomId(roomId);
+          chat.joinRoom(roomId);
+        } else {
+          setSelectedRoomId(null);
+        }
+      };
+
+      if (savedUserId) {
+        apiRequest(`/api/users/${savedUserId}`)
+          .then(proceedWithUser)
+          .catch(() => {})
+          .finally(() => setIsRestoring(false));
+      } else {
+        apiRequest('/api/auth/session')
+          .then((data: any) => {
+            if (data?.user) {
+              proceedWithUser(data.user);
+            } else {
+              setShowWelcome(true);
+            }
+          })
+          .catch(() => setShowWelcome(true))
+          .finally(() => setIsRestoring(false));
       }
-
-      // Fetch user data from server
-      apiRequest(`/api/users/${savedUserId}`)
-        .then((user) => {
-          if (!user || !user.id || !user.username) return;
-          chat.connect(user);
-          setShowWelcome(false);
-
-          const roomId = session?.roomId && session.roomId !== 'public' && session.roomId !== 'friends'
-            ? session.roomId
-            : null;
-          if (roomId) {
-            setSelectedRoomId(roomId);
-            chat.joinRoom(roomId);
-          } else {
-            setSelectedRoomId(null); // المستخدم سيختار الغرفة من واجهة الغرف
-          }
-        })
-        .catch(() => {})
-        .finally(() => setIsRestoring(false));
     } catch {
       setIsRestoring(false);
     }


### PR DESCRIPTION
Enhance user session persistence and ensure full socket connection on refresh by moving client session storage to `localStorage`, adding a server-side session restoration endpoint, and delaying room joins until after socket authentication.

---
<a href="https://cursor.com/background-agent?bcId=bc-6d19e8d8-9f5e-439d-afaf-0b14659d2e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6d19e8d8-9f5e-439d-afaf-0b14659d2e64">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

