### PR TITLE
Fix join system bot user confusion

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -239,7 +239,8 @@ async function joinRoom(
       socket.leave(`room_${previousRoom}`);
       // رسالة نظامية: مغادرة الغرفة السابقة
       try {
-        const user = entry?.user || (await storage.getUser(userId));
+        const localEntry = connectedUsers.get(userId);
+        const user = localEntry?.user || (await storage.getUser(userId));
         const content = formatRoomEventMessage('leave', {
           username,
           userType: user?.userType,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -483,7 +483,55 @@ interface LegacyStorage {
 export const storage: LegacyStorage = {
   async getUser(id: number) {
     const user = await databaseService.getUserById(id);
-    return user || undefined;
+    if (user) return user as any;
+    // Fallback: fetch from bots table and map to ChatUser-like object
+    try {
+      const { db, dbType } = await import('./database-adapter');
+      if (!db || dbType !== 'postgresql') return undefined;
+      const { bots } = await import('../shared/schema');
+      const { eq } = await import('drizzle-orm');
+      const rows = await (db as any)
+        .select()
+        .from(bots as any)
+        .where(eq((bots as any).id, id as any))
+        .limit(1);
+      const bot = rows?.[0];
+      if (!bot) return undefined;
+      const mapped = {
+        id: bot.id,
+        username: bot.username,
+        userType: 'bot',
+        role: 'bot',
+        profileImage: bot.profileImage,
+        profileBanner: bot.profileBanner,
+        profileBackgroundColor: bot.profileBackgroundColor,
+        status: bot.status,
+        gender: bot.gender,
+        country: bot.country,
+        relation: bot.relation,
+        bio: bot.bio,
+        isOnline: !!bot.isOnline,
+        isHidden: false,
+        lastSeen: bot.lastActivity,
+        joinDate: bot.createdAt,
+        createdAt: bot.createdAt,
+        isMuted: false,
+        muteExpiry: null,
+        isBanned: false,
+        banExpiry: null,
+        isBlocked: false,
+        usernameColor: bot.usernameColor,
+        profileEffect: bot.profileEffect,
+        points: bot.points,
+        level: bot.level,
+        totalPoints: bot.totalPoints,
+        levelProgress: bot.levelProgress,
+        currentRoom: bot.currentRoom,
+      } as any;
+      return mapped;
+    } catch (e) {
+      return undefined;
+    }
   },
 
   async getUserByUsername(username: string) {

--- a/server/utils/roomEventFormatter.ts
+++ b/server/utils/roomEventFormatter.ts
@@ -4,6 +4,8 @@ export type RoomEventAction = 'join' | 'leave' | 'switch';
 
 function getArabicRole(userType?: string): string {
   switch ((userType || '').toLowerCase()) {
+    case 'bot':
+      return 'بوت';
     case 'guest':
       return 'زائر';
     case 'member':


### PR DESCRIPTION
Fixes incorrect display of user types (bot vs. real user) in join, leave, and room switch system messages.

---
<a href="https://cursor.com/background-agent?bcId=bc-42c8bf96-7129-4f03-9117-af3b56ece3f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-42c8bf96-7129-4f03-9117-af3b56ece3f7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

