### PR TITLE
Debug bot join message functionality

### DIFF
--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -1701,6 +1701,16 @@ export class DatabaseService {
     roomId: string,
     userId: number
   ): Promise<{ allowed: boolean; reason?: string }> {
+    // Bots are server-managed entities. Allow them to send room messages
+    // (e.g., system join/leave when moved) regardless of DB membership.
+    // This avoids blocking legitimate system messages after introducing per-room checks.
+    try {
+      const { isBotId } = await import('../types/entities');
+      if (isBotId(userId)) {
+        return { allowed: true };
+      }
+    } catch {}
+
     if (!this.isConnected()) return { allowed: true };
 
     try {


### PR DESCRIPTION
Allow bots to send room messages regardless of `room_members` status to fix missing join/leave messages when bots are moved.

The `canSendInRoom` check was preventing server-managed bot system messages (e.g., join/leave when moved) because the bot was not yet a member of the `room_members` table, causing these messages to not appear.

---
<a href="https://cursor.com/background-agent?bcId=bc-c26ffe64-9693-4ecd-b970-9638c0b1282d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c26ffe64-9693-4ecd-b970-9638c0b1282d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

