### PR TITLE
Investigate duplicate bot join messages

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -88,7 +88,7 @@ export function updateConnectedUserCache(userOrId: any, maybeUser?: any) {
       if (existing) {
         existing.user = { ...existing.user, ...userObj };
         existing.lastSeen = new Date();
-        // إذا كان بوتاً ولديه socket اصطناعي، حدّث الغرفة
+        // إذا كان بوتاً ولديه socket اصطناعي، حدّث الغرفة بصمت (بدون إرسال رسائل)
         if (userObj.userType === 'bot') {
           for (const [socketId, socketMeta] of existing.sockets.entries()) {
             if (socketId.startsWith('bot:')) {
@@ -213,11 +213,23 @@ async function buildOnlineUsersForRoom(roomId: string) {
 
 // أزيلت دالة إبطال الكاش
 
+// تتبع آخر تحديث لكل غرفة لمنع الإرسال المتكرر
+const lastRoomUpdate = new Map<string, number>();
+
 // بث قائمة المتصلين لغرفة معينة (لاستخدامه من المسارات الخارجية كبوتات)
 export async function emitOnlineUsersForRoom(roomId: string): Promise<void> {
   try {
     if (!roomId) return;
     if (!ioInstance) return;
+    
+    // منع الإرسال المتكرر خلال فترة قصيرة (200ms)
+    const now = Date.now();
+    const lastUpdate = lastRoomUpdate.get(roomId) || 0;
+    if (now - lastUpdate < 200) {
+      return;
+    }
+    lastRoomUpdate.set(roomId, now);
+    
     const users = await buildOnlineUsersForRoom(roomId);
     ioInstance.to(`room_${roomId}`).emit('message', {
       type: 'onlineUsers',

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4493,27 +4493,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
         .where(eq(bots.id, botId))
         .returning();
 
-      // رسالة نظامية لمغادرة الغرفة القديمة
-      try {
-        const leaveContent = formatRoomEventMessage('leave', {
-          username: updatedBot.username,
-          userType: 'bot',
-          level: updatedBot.level as any,
-        });
-        const leaveMsg = await storage.createMessage({
-          senderId: botId,
-          roomId: oldRoom,
-          content: leaveContent,
-          messageType: 'system',
-          isPrivate: false,
-        });
-        const sender = await storage.getUser(botId);
-        getIO().to(`room_${oldRoom}`).emit('message', {
-          type: 'newMessage',
-          message: { ...leaveMsg, sender, roomId: oldRoom, reactions: { like: 0, dislike: 0, heart: 0 }, myReaction: null },
-        });
-      } catch {}
-
       // إشعار بدخول الغرفة الجديدة - تضمين الحقول التعريفية للبوت
       const botUser = {
         id: updatedBot.id,
@@ -4535,6 +4514,33 @@ export async function registerRoutes(app: Express): Promise<Server> {
         currentRoom: roomId,
       };
 
+      // تحديث cache المستخدمين المتصلين أولاً قبل إرسال الرسائل
+      updateConnectedUserCache(updatedBot.id, botUser);
+
+      // رسالة نظامية لمغادرة الغرفة القديمة
+      try {
+        const leaveContent = formatRoomEventMessage('leave', {
+          username: updatedBot.username,
+          userType: 'bot',
+          level: updatedBot.level as any,
+        });
+        const leaveMsg = await storage.createMessage({
+          senderId: botId,
+          roomId: oldRoom,
+          content: leaveContent,
+          messageType: 'system',
+          isPrivate: false,
+        });
+        const sender = await storage.getUser(botId);
+        getIO().to(`room_${oldRoom}`).emit('message', {
+          type: 'newMessage',
+          message: { ...leaveMsg, sender, roomId: oldRoom, reactions: { like: 0, dislike: 0, heart: 0 }, myReaction: null },
+        });
+      } catch {}
+
+      // رسالة واحدة فقط للانضمام - مع تأخير قصير لتجنب التداخل
+      await new Promise(resolve => setTimeout(resolve, 100));
+      
       try {
         const joinContent = formatRoomEventMessage('join', {
           username: updatedBot.username,
@@ -4555,9 +4561,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
         });
       } catch {}
 
-      // تحديث cache المستخدمين المتصلين بالبيانات الجديدة
-      updateConnectedUserCache(updatedBot.id, botUser);
-
       // تنظيف cache الرسائل للغرف المتأثرة لضمان عرض البيانات الصحيحة
       try {
         const { roomMessageService } = await import('./services/roomMessageService');
@@ -4567,7 +4570,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         console.error('خطأ في تنظيف cache الرسائل:', e);
       }
 
-      // إرسال تحديث قائمة المستخدمين للغرف المتأثرة (قائمة كاملة لتفادي عدم التزامن)
+      // إرسال تحديث قائمة المستخدمين للغرف المتأثرة (بدون إرسال رسائل إضافية)
       try {
         await emitOnlineUsersForRoom(oldRoom);
         await emitOnlineUsersForRoom(roomId);


### PR DESCRIPTION
Fixes duplicate bot join messages by synchronizing cache updates, adding a delay, and debouncing online user emissions.

The issue stemmed from a race condition where the bot move API explicitly sent a join message, while a subsequent cache update and online user emission could implicitly trigger another join message or related event, leading to two messages. The changes ensure a single, controlled join message is sent by synchronizing cache updates, introducing a small delay, and preventing rapid, redundant online user broadcasts.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a32b7d8-473a-4b76-8744-55979c19b233">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2a32b7d8-473a-4b76-8744-55979c19b233">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

