### PR TITLE
Fix bot room change and user departure messages

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -76,6 +76,21 @@ export function getOnlineUserCountForRoom(roomId: string): number {
   return count;
 }
 
+// جلب الغرف النشطة الحالية لمستخدم من connectedUsers
+export function getUserActiveRooms(userId: number): string[] {
+  try {
+    const entry = connectedUsers.get(userId);
+    if (!entry) return [];
+    const rooms = new Set<string>();
+    for (const socketMeta of entry.sockets.values()) {
+      if (socketMeta.room) rooms.add(socketMeta.room);
+    }
+    return Array.from(rooms.values());
+  } catch {
+    return [];
+  }
+}
+
 // إزالة كاش قائمة المتصلين للغرف للاعتماد الكامل على أحداث Socket.IO
 
 export function updateConnectedUserCache(userOrId: any, maybeUser?: any) {

--- a/server/utils/roomEventFormatter.ts
+++ b/server/utils/roomEventFormatter.ts
@@ -1,6 +1,6 @@
 import { getLevelInfo } from '../../shared/points-system';
 
-export type RoomEventAction = 'join' | 'leave' | 'switch';
+export type RoomEventAction = 'join' | 'leave' | 'switch' | 'site_leave';
 
 function getArabicRole(userType?: string): string {
   switch ((userType || '').toLowerCase()) {
@@ -61,6 +61,9 @@ export function formatRoomEventMessage(
   }
   if (action === 'leave') {
     return `غادر الغرفة (${meta})`;
+  }
+  if (action === 'site_leave') {
+    return `المستخدم غادر الموقع (${meta})`;
   }
   // switch
   const fromName = extra?.fromRoomName || 'غرفة سابقة';


### PR DESCRIPTION
Unify system messages for bot disable/delete and user logout to "المستخدم غادر الموقع" (User left the site) for consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-9badb125-9b48-490b-81a6-2caf9e012873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9badb125-9b48-490b-81a6-2caf9e012873">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

