### PR TITLE
Remove bot logo from chat rooms

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -577,7 +577,7 @@ export default function MessageArea({
                       </div>
                     )}
                     <div className={`flex-1 min-w-0 flex ${isMobile ? 'flex-wrap items-start' : 'items-center'} gap-2`}>
-                      {message.sender && (
+                      {message.sender && message.sender.userType !== 'bot' && (
                         <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={16} />
                       )}
                       <button
@@ -613,7 +613,7 @@ export default function MessageArea({
 
                     {/* Inline row: badge, name, content */}
                     <div className={`flex-1 min-w-0 flex ${isMobile ? 'flex-wrap items-start' : 'items-center'} gap-2`}>
-                      {message.sender && (
+                      {message.sender && message.sender.userType !== 'bot' && (
                         <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={16} />
                       )}
                       <button


### PR DESCRIPTION
Hide bot badges in room chat messages to display bots as regular users.

---
<a href="https://cursor.com/background-agent?bcId=bc-1345da13-8e88-4bf2-b33c-e0da0a2e1570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1345da13-8e88-4bf2-b33c-e0da0a2e1570">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

