### PR TITLE
Fix mobile top bar spacing and admin bar

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2084,6 +2084,19 @@ li::before {
     -webkit-backdrop-filter: blur(20px) saturate(180%);
     box-shadow: 0 -2px 20px rgba(0, 0, 0, 0.1);
   }
+
+  /* Match top bar spacing with bottom bar on mobile without altering design */
+  .mobile-header > div {
+    gap: 0.25rem !important; /* equals gap-1 */
+  }
+
+  .mobile-header .glass-effect {
+    padding-left: 0.5rem !important;  /* px-2 */
+    padding-right: 0.5rem !important; /* px-2 */
+    padding-top: 0.5rem !important;   /* py-2 */
+    padding-bottom: 0.5rem !important;/* py-2 */
+    gap: 0.375rem !important;         /* equals gap-1.5 like footer buttons */
+  }
   
   .mobile-footer {
     border-top: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
Adjust mobile top bar spacing to match the bottom bar, including the admin top bar, as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-16881242-a29c-4a9a-8843-8a5aaa6c4f1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16881242-a29c-4a9a-8843-8a5aaa6c4f1a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

