### PR TITLE
Adapt bottom nav design to top bar

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -724,7 +724,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             onClick={() => setShowSettings(!showSettings)}
           >
             <Settings className="w-4 h-4" />
-            <span className={`font-medium ${isMobile ? 'text-xs' : ''}`}>إعدادات</span>
+            <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إعدادات</span>
           </Button>
 
           <Button
@@ -737,13 +737,15 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             title="الأثرياء"
           >
             <Crown className="w-4 h-4 text-yellow-400" />
-            <span className={`font-medium ${isMobile ? 'text-xs' : ''}`}>الأثرياء</span>
+            <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>الأثرياء</span>
           </Button>
 
           {/* زر إضافة غرفة جديدة للمالك */}
           {chat.currentUser && chat.currentUser.userType === 'owner' && (
             <Button
-              className="glass-effect px-3 py-2 rounded-lg hover:bg-accent transition-all duration-200 flex items-center gap-2"
+              className={`glass-effect rounded-lg hover:bg-accent transition-all duration-200 flex items-center gap-2 ${
+                isMobile ? 'px-2 py-2' : 'px-3 py-2'
+              }`}
               onClick={() => setShowAddRoomDialog(true)}
             >
               <svg
@@ -761,18 +763,20 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                 <line x1="12" y1="8" x2="12" y2="16"></line>
                 <line x1="8" y1="12" x2="16" y2="12"></line>
               </svg>
-              <span className="font-medium">إضافة غرفة</span>
+              <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إضافة غرفة</span>
             </Button>
           )}
 
           {/* زر خاص بالمالك فقط */}
           {chat.currentUser && chat.currentUser.userType === 'owner' && (
             <Button
-              className="glass-effect px-4 py-2 rounded-lg hover:bg-purple-600 transition-all duration-200 flex items-center gap-2 border border-purple-400"
+              className={`glass-effect rounded-lg hover:bg-purple-600 transition-all duration-200 flex items-center gap-2 border border-purple-400 ${
+                isMobile ? 'px-2 py-2' : 'px-4 py-2'
+              }`}
               onClick={() => setShowOwnerPanel(true)}
             >
               <Crown className="w-4 h-4" />
-              إدارة المالك
+              <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إدارة المالك</span>
             </Button>
           )}
 
@@ -783,28 +787,34 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                 {/* زر ترقية المستخدمين - للمالك فقط */}
                 {chat.currentUser?.userType === 'owner' && (
                   <Button
-                    className="glass-effect px-4 py-2 rounded-lg hover:bg-blue-600 transition-all duration-200 flex items-center gap-2"
+                    className={`glass-effect rounded-lg hover:bg-blue-600 transition-all duration-200 flex items-center gap-2 ${
+                      isMobile ? 'px-2 py-2' : 'px-4 py-2'
+                    }`}
                     onClick={() => setShowPromotePanel(true)}
                   >
                     <Crown className="w-4 h-4" />
-                    ترقية المستخدمين
+                    <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>ترقية المستخدمين</span>
                   </Button>
                 )}
 
                 <Button
-                  className="glass-effect px-4 py-2 rounded-lg hover:bg-yellow-600 transition-all duration-200 flex items-center gap-2 border border-yellow-400"
+                  className={`glass-effect rounded-lg hover:bg-yellow-600 transition-all duration-200 flex items-center gap-2 border border-yellow-400 ${
+                    isMobile ? 'px-2 py-2' : 'px-4 py-2'
+                  }`}
                   onClick={() => setShowActiveActions(true)}
                 >
                   <Lock className="w-4 h-4" />
-                  سجل الإجراءات النشطة
+                  <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>سجل الإجراءات النشطة</span>
                 </Button>
 
                 <Button
-                  className="glass-effect px-4 py-2 rounded-lg hover:bg-red-600 transition-all duration-200 flex items-center gap-2 border border-red-400 relative"
+                  className={`glass-effect rounded-lg hover:bg-red-600 transition-all duration-200 flex items-center gap-2 border border-red-400 relative ${
+                    isMobile ? 'px-2 py-2' : 'px-4 py-2'
+                  }`}
                   onClick={() => setShowReportsLog(true)}
                 >
                   <AlertTriangle className="w-4 h-4" />
-                  سجل البلاغات
+                  <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>سجل البلاغات</span>
                   {pendingReportsCount > 0 && (
                     <span className="absolute -top-2 -right-2 inline-flex items-center justify-center text-[10px] min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white">
                       {pendingReportsCount}
@@ -813,7 +823,9 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                 </Button>
 
                 <Button
-                  className="glass-effect px-4 py-2 rounded-lg transition-all duration-200 flex items-center gap-2 border"
+                  className={`glass-effect rounded-lg transition-all duration-200 flex items-center gap-2 border ${
+                    isMobile ? 'px-2 py-2' : 'px-4 py-2'
+                  }`}
                   onClick={async () => {
                     if (!chat.currentUser) return;
                     try {
@@ -832,22 +844,24 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                   {chat.currentUser?.isHidden ? (
                     <>
                       <Eye className="w-4 h-4" />
-                      <span>إظهار</span>
+                      <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إظهار</span>
                     </>
                   ) : (
                     <>
                       <EyeOff className="w-4 h-4" />
-                      <span>إخفاء</span>
+                      <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إخفاء</span>
                     </>
                   )}
                 </Button>
 
                 <Button
-                  className="glass-effect px-4 py-2 rounded-lg hover:bg-accent transition-all duration-200 flex items-center gap-2"
+                  className={`glass-effect rounded-lg hover:bg-accent transition-all duration-200 flex items-center gap-2 ${
+                    isMobile ? 'px-2 py-2' : 'px-4 py-2'
+                  }`}
                   onClick={() => setShowModerationPanel(true)}
                 >
                   <Shield className="w-4 h-4" />
-                  إدارة
+                  <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إدارة</span>
                 </Button>
               </>
             )}
@@ -860,7 +874,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             title="الرسائل"
           >
             <MessageSquare className="w-4 h-4" />
-            <span className={isMobile ? 'text-xs' : ''}>الرسائل</span>
+            <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>الرسائل</span>
             {totalUnreadPrivateMessages > 0 && (
               <span className="ml-2 inline-flex items-center justify-center text-[10px] min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white">
                 {totalUnreadPrivateMessages}
@@ -875,7 +889,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             onClick={() => setShowNotifications(true)}
           >
             <Bell className="w-4 h-4" />
-            <span className={isMobile ? 'text-xs' : ''}>إشعارات</span>
+            <span className={`font-medium ${isMobile ? 'text-xs tab-text-hide' : ''}`}>إشعارات</span>
             {unreadNotificationsCount > 0 && (
               <span className="ml-2 inline-flex items-center justify-center text-[10px] min-w-[18px] h-[18px] px-1 rounded-full bg-red-600 text-white">
                 {unreadNotificationsCount}


### PR DESCRIPTION
Make the top navigation bar on mobile devices display icons only, matching the bottom navigation bar's design.

The user requested that the top navigation bar on mobile devices should only show icons, without text labels, to match the existing design of the bottom navigation bar. This was achieved by applying the `tab-text-hide` class to the text elements within the top navigation buttons and adjusting padding for a consistent mobile layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-d59a8ddb-98a5-49e7-8b36-c3f753e291d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d59a8ddb-98a5-49e7-8b36-c3f753e291d7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

