### PR TITLE
Fix chat room positioning bug

### DIFF
--- a/client/src/components/chat/BroadcastRoomInterface.tsx
+++ b/client/src/components/chat/BroadcastRoomInterface.tsx
@@ -1014,7 +1014,7 @@ export default function BroadcastRoomInterface({
       {/* تخطيط سطح المكتب: عمود جانبي يسار + منطقة الرسائل */}
       <div className="flex-1 min-h-0 flex">
         {/* منطقة الرسائل */}
-        <div className="flex-1 min-h-0">
+        <div className="flex-1 min-h-0 flex flex-col">
           <MessageArea
             messages={messages}
             currentUser={currentUser}


### PR DESCRIPTION
Add `flex flex-col` to the `MessageArea` wrapper in `BroadcastRoomInterface.tsx` to fix the chat input area not sticking to the bottom in broadcast rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-7407b23b-6d88-404a-894f-345c19d4832a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7407b23b-6d88-404a-894f-345c19d4832a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

