### PR TITLE
Add private message blocking options

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -54,6 +54,8 @@ export const users = pgTable('users', {
   profileMusicTitle: text('profile_music_title'),
   profileMusicEnabled: boolean('profile_music_enabled').default(true),
   profileMusicVolume: integer('profile_music_volume').default(70),
+  // إعداد خصوصية الرسائل الخاصة: all | friends | none
+  dmPrivacy: text('dm_privacy').notNull().default('all'),
 });
 
 export const messages = pgTable(
@@ -405,6 +407,8 @@ export const insertUserSchema = z.object({
   level: z.number().optional(),
   totalPoints: z.number().optional(),
   levelProgress: z.number().optional(),
+  // خصوصية الرسائل الخاصة
+  dmPrivacy: z.enum(['all', 'friends', 'none']).optional(),
 });
 
 export const insertMessageSchema = z.object({


### PR DESCRIPTION
Add `dmPrivacy` field to user schema to support private message privacy settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-72704c08-31c3-4866-b7ee-60bc20bccfe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-72704c08-31c3-4866-b7ee-60bc20bccfe0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

