### PR TITLE
Investigate persistent sessions after logout

### DIFF
--- a/client/src/pages/CountryChat.tsx
+++ b/client/src/pages/CountryChat.tsx
@@ -99,7 +99,15 @@ export default function CountryChat() {
     chat.joinRoom(roomId);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      // استدعاء API تسجيل الخروج لمسح الكوكي من الخادم
+      await apiRequest('/api/auth/logout', { method: 'POST' });
+    } catch (error) {
+      console.error('خطأ في تسجيل الخروج:', error);
+      // نكمل عملية الخروج حتى لو فشل الطلب
+    }
+    
     clearSession();
     chat.disconnect();
     setShowWelcome(true);

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -107,7 +107,15 @@ export default function ChatPage() {
     chat.joinRoom(roomId);
   };
 
-  const handleLogout = () => {
+  const handleLogout = async () => {
+    try {
+      // استدعاء API تسجيل الخروج لمسح الكوكي من الخادم
+      await apiRequest('/api/auth/logout', { method: 'POST' });
+    } catch (error) {
+      console.error('خطأ في تسجيل الخروج:', error);
+      // نكمل عملية الخروج حتى لو فشل الطلب
+    }
+    
     clearSession(); // مسح بيانات الجلسة المحفوظة
     chat.disconnect();
     setShowWelcome(true);


### PR DESCRIPTION
Add server-side logout API call to `handleLogout` to properly terminate user sessions and invalidate the `auth_token` cookie.

Previously, client-side logout only cleared local storage, leaving the `auth_token` cookie intact. This allowed sessions to persist and be restored upon page reload, as the server's `/api/auth/session` endpoint would still validate the existing cookie. The fix ensures the server is explicitly notified to invalidate the session and clear the cookie.

---
<a href="https://cursor.com/background-agent?bcId=bc-edfa9142-f05a-44fd-9972-5d5fe7eda3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edfa9142-f05a-44fd-9972-5d5fe7eda3ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

