### PR TITLE
Apply database fixes and start application

### DIFF
--- a/deploy-fix.js
+++ b/deploy-fix.js
@@ -71,6 +71,25 @@ async function applyDeploymentFixes() {
     await sql`UPDATE "users" SET "dm_privacy" = 'all' WHERE "dm_privacy" IS NULL OR "dm_privacy" NOT IN ('all','friends','none')`;
     await sql`ALTER TABLE "users" ALTER COLUMN "dm_privacy" SET DEFAULT 'all'`;
     await sql`ALTER TABLE "users" ALTER COLUMN "dm_privacy" SET NOT NULL`;
+
+    // Ensure user preference columns exist and are defaulted
+    console.log('🔍 التحقق من أعمدة تفضيلات المستخدم العامة في users...');
+    await sql`ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS show_points_to_others BOOLEAN`;
+    await sql`ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS show_system_messages BOOLEAN`;
+    await sql`ALTER TABLE IF EXISTS users ADD COLUMN IF NOT EXISTS global_sound_enabled BOOLEAN`;
+
+    console.log('🔄 ضبط القيم الافتراضية لأعمدة التفضيلات...');
+    await sql`UPDATE users SET show_points_to_others = COALESCE(show_points_to_others, TRUE)`;
+    await sql`UPDATE users SET show_system_messages = COALESCE(show_system_messages, TRUE)`;
+    await sql`UPDATE users SET global_sound_enabled = COALESCE(global_sound_enabled, TRUE)`;
+
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN show_points_to_others SET DEFAULT TRUE`;
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN show_system_messages SET DEFAULT TRUE`;
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN global_sound_enabled SET DEFAULT TRUE`;
+
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN show_points_to_others SET NOT NULL`;
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN show_system_messages SET NOT NULL`;
+    await sql`ALTER TABLE IF EXISTS users ALTER COLUMN global_sound_enabled SET NOT NULL`;
     
     // Verify the fix worked
     console.log('✅ التحقق من النتيجة النهائية...');

--- a/server/database-setup.ts
+++ b/server/database-setup.ts
@@ -22,6 +22,7 @@ import { ensureUserProfileMusicColumns } from './database-adapter';
 import { ensureRoomsColumns } from './database-adapter';
 import { ensureBotsTable } from './database-adapter';
 import { ensureChatLockColumns } from './database-adapter';
+import { ensureUserPreferencesColumns } from './database-adapter';
 
 // إعادة تصدير دالة التهيئة من المحول
 export { initializeDatabase } from './database-adapter';
@@ -277,6 +278,13 @@ export async function initializeSystem(): Promise<boolean> {
       await ensureUserProfileMusicColumns();
     } catch (e) {
       console.warn('⚠️ تعذر ضمان أعمدة موسيقى البروفايل:', (e as any)?.message || e);
+    }
+
+    // ضمان أعمدة تفضيلات المستخدم العامة
+    try {
+      await ensureUserPreferencesColumns();
+    } catch (e) {
+      console.warn('⚠️ تعذر ضمان أعمدة تفضيلات المستخدم:', (e as any)?.message || e);
     }
 
     // ضمان أعمدة جدول الغرف (مثل is_locked)


### PR DESCRIPTION
Add missing user preference columns to the `users` table and ensure they are defaulted.

The application was crashing with `PostgresError: column "show_points_to_others" does not exist` because several user preference columns were missing from the database schema. This PR adds a safeguard to create these columns with default values (`TRUE`) and enforce `NOT NULL` constraints during both the deployment fix script execution and application initialization, preventing these startup failures.

---
<a href="https://cursor.com/background-agent?bcId=bc-8064c3a1-4782-4645-ad9b-f187ec9aa3cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8064c3a1-4782-4645-ad9b-f187ec9aa3cd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

