### PR TITLE
Remove irrelevant profile option and fix user status

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2614,23 +2614,26 @@ export default function ProfileModal({
               >
                 معلوماتي
               </button>
-              <button
-                onClick={() => setActiveTab('options')}
-                style={{
-                  flex: 1,
-                  padding: '8px',
-                  background: activeTab === 'options' ? 'rgba(255,255,255,0.1)' : 'transparent',
-                  color: '#fff',
-                  border: 'none',
-                  fontSize: '14px',
-                  fontWeight: 'bold',
-                  cursor: 'pointer',
-                  transition: 'background 0.2s ease',
-                  borderRight: '1px solid rgba(255,255,255,0.08)'
-                }}
-              >
-                خيارات
-              </button>
+              {/* إخفاء تبويب "خيارات" للمستخدمين الآخرين لأنه فارغ */}
+              {localUser?.id === currentUser?.id && (
+                <button
+                  onClick={() => setActiveTab('options')}
+                  style={{
+                    flex: 1,
+                    padding: '8px',
+                    background: activeTab === 'options' ? 'rgba(255,255,255,0.1)' : 'transparent',
+                    color: '#fff',
+                    border: 'none',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    cursor: 'pointer',
+                    transition: 'background 0.2s ease',
+                    borderRight: '1px solid rgba(255,255,255,0.08)'
+                  }}
+                >
+                  خيارات
+                </button>
+              )}
               <button
                 onClick={() => setActiveTab('other')}
                 style={{

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2672,14 +2672,20 @@ export default function ProfileModal({
               
               <div className="profile-info">
                 <small
+                  onClick={() => localUser?.id === currentUser?.id && openEditModal('status')}
                   style={{ 
                     display: 'block', 
                     textAlign: 'center',
                     width: '100%',
-                    margin: '0 auto 12px auto'
+                    margin: '0 auto 12px auto',
+                    cursor: localUser?.id === currentUser?.id ? 'pointer' : 'default',
+                    color: '#ddd',
+                    fontSize: '13px',
+                    fontStyle: 'italic'
                   }}
+                  title={localUser?.id === currentUser?.id ? 'اضغط لتعديل الحالة' : ''}
                 >
-                  {lastSeenText}
+                  {localUser?.status || 'لا توجد حالة'}
                 </small>
               </div>
 

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2685,7 +2685,7 @@ export default function ProfileModal({
                   }}
                   title={localUser?.id === currentUser?.id ? 'اضغط لتعديل الحالة' : ''}
                 >
-                  {localUser?.status || 'لا توجد حالة'}
+                  {localUser?.status || ''}
                 </small>
               </div>
 


### PR DESCRIPTION
Remove the empty "خيارات" (options) tab from other users' profiles.

The "خيارات" tab was empty when viewing another user's profile, leading to a confusing user experience. This change hides the tab for other users while keeping it visible for the current user's own profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-99ae8718-81ef-42f0-9488-3da76d098318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-99ae8718-81ef-42f0-9488-3da76d098318">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

