### PR TITLE
Delete under development profile tab

### DIFF
--- a/attached_assets/Pasted--DOCTYPE-html-html-lang-ar-dir-rtl-head-meta-charset-UTF-8-title--1752118537868_1752118537868.txt
+++ b/attached_assets/Pasted--DOCTYPE-html-html-lang-ar-dir-rtl-head-meta-charset-UTF-8-title--1752118537868_1752118537868.txt
@@ -131,7 +131,6 @@
     <button onclick="switchTab('friends')">الأصدقاء</button>
     <button onclick="switchTab('ignore')">تجاهل</button>
     <button onclick="switchTab('options')">خيارات</button>
-    <button onclick="switchTab('more')">المزيد</button>
   </div>
   <div id="profileContent">
     <div id="info" class="tab-section active">
@@ -214,7 +213,6 @@
         </div>
       </div>
     </div>
-    <div id="more" class="tab-section">قسم المزيد قيد التطوير...</div>
   </div>
   <div class="text-center mt-6">
     <button onclick="saveProfile()" class="bg-green-600 px-4 py-2 rounded font-bold">✔️ حفظ وإغلاق</button>
@@ -588,7 +586,6 @@ window.addEventListener("load", () => {
     <button onclick="switchTab('friends')">الأصدقاء</button>
     <button onclick="switchTab('ignore')">تجاهل</button>
     <button onclick="switchTab('options')">خيارات</button>
-    <button onclick="switchTab('more')">المزيد</button>
   </div>
 
   <div id="profileContent">
@@ -670,7 +667,6 @@ window.addEventListener("load", () => {
       </div>
     </div>
 
-    <div id="more" class="tab-section">قسم المزيد قيد التطوير...</div>
   </div>
 
   <div class="text-center mt-6">

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2648,7 +2648,7 @@ export default function ProfileModal({
                   transition: 'background 0.2s ease'
                 }}
               >
-                {localUser?.id === currentUser?.id ? 'قيد التطوير' : 'الأصدقاء'}
+                الأصدقاء
               </button>
             </div>
 
@@ -2812,7 +2812,6 @@ export default function ProfileModal({
                     background: 'rgba(255,255,255,0.04)'
                   }}>
                     <span style={{ color: '#fff', fontSize: '14px' }}>👥 طلبات الصداقة</span>
-                    <span style={{ color: '#888', fontSize: '12px' }}>قيد التطوير</span>
                   </div>
 
 
@@ -3142,13 +3141,42 @@ export default function ProfileModal({
               borderBottom: '1px solid rgba(255,255,255,0.1)',
               paddingBottom: '8px'
             }}>
-              {localUser?.id === currentUser?.id ? 'قيد التطوير' : 'الأصدقاء'}
+              الأصدقاء
             </h4>
             
             {localUser?.id === currentUser?.id ? (
-              <p style={{ color: '#888', fontSize: '14px', textAlign: 'center' }}>
-                هذا القسم قيد التطوير وسيتم إضافة المزيد من الميزات قريباً
-              </p>
+              <div>
+                {loadingFriends ? (
+                  <div style={{ textAlign: 'center', color: '#888', fontSize: '14px' }}>
+                    جاري تحميل الأصدقاء...
+                  </div>
+                ) : friends.length === 0 ? (
+                  <div style={{ textAlign: 'center', color: '#888', fontSize: '14px' }}>
+                    لا يوجد أصدقاء بعد
+                  </div>
+                ) : (
+                  <div>
+                    {friends.map(friend => (
+                      <div key={friend.id} style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        marginBottom: '8px',
+                        padding: '8px',
+                        borderRadius: '6px',
+                        background: 'rgba(255,255,255,0.04)'
+                      }}>
+                        <img 
+                          src={friend.profileImage || '/default-avatar.png'} 
+                          alt={friend.username}
+                          style={{ width: '32px', height: '32px', borderRadius: '50%' }}
+                        />
+                        <span style={{ color: '#fff', fontSize: '14px' }}>{friend.username}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
             ) : (
               <div>
                 {loadingFriends ? (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove the "Under Development" tab and activate the Friends section in the profile modal.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The "Under Development" tab and its placeholder content were removed from the profile. This change also replaces the "Under Development" message with the actual display logic for the Friends list, including loading states and a message for when no friends are present.

---
<a href="https://cursor.com/background-agent?bcId=bc-d2f7e6c0-b538-4775-8e22-cc590d2bc8a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d2f7e6c0-b538-4775-8e22-cc590d2bc8a6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

