### PR TITLE
Align friend tabs with status box

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2591,7 +2591,7 @@ export default function ProfileModal({
             {/* Tab Navigation */}
             <div style={{
               display: 'flex',
-              marginBottom: '16px',
+              marginBottom: '0px',
               borderRadius: '8px',
               background: 'rgba(255,255,255,0.04)',
               border: '1px solid rgba(255,255,255,0.08)',


### PR DESCRIPTION
Remove the vertical gap between tabs and the content box by setting `marginBottom` to 0px.

---
<a href="https://cursor.com/background-agent?bcId=bc-80803a2f-f494-4ff6-b11c-3b1b2150b5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80803a2f-f494-4ff6-b11c-3b1b2150b5b8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

