### PR TITLE
Adjust friend info tab layout

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2298,7 +2298,7 @@ export default function ProfileModal({
           }
           
           .profile-body {
-            padding: 50px 12px 12px;
+            padding: 58px 12px 10px;
           }
           
           .profile-info h3 {
@@ -2655,7 +2655,7 @@ export default function ProfileModal({
             {/* Tab Content */}
             {activeTab === 'info' && (
               <div style={{ 
-                padding: '12px',
+                padding: '10px',
                 borderRadius: '8px',
                 border: '1px solid rgba(255,255,255,0.08)',
                 background: 'rgba(255,255,255,0.04)'
@@ -2750,7 +2750,7 @@ export default function ProfileModal({
             {/* Tab Content - Options */}
             {activeTab === 'options' && localUser?.id === currentUser?.id && (
               <div style={{ 
-                padding: '12px',
+                padding: '10px',
                 borderRadius: '8px',
                 border: '1px solid rgba(255,255,255,0.08)',
                 background: 'rgba(255,255,255,0.04)'


### PR DESCRIPTION
Move profile tabs down slightly and reduce modal content height to prevent image overlap.

---
<a href="https://cursor.com/background-agent?bcId=bc-80bda10c-1809-4740-9cb6-924fea04da28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-80bda10c-1809-4740-9cb6-924fea04da28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

