### PR TITLE
Adjust friend info tab layout

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1698,7 +1698,7 @@ export default function ProfileModal({
         }
 
         .profile-body {
-          padding: 20px 20px 10px;
+          padding: 8px 20px 10px;
         }
 
         .profile-info {
@@ -2298,7 +2298,7 @@ export default function ProfileModal({
           }
           
           .profile-body {
-            padding: 58px 12px 10px;
+            padding: 35px 12px 10px;
           }
           
           .profile-info h3 {


### PR DESCRIPTION
Reduce the top padding of `.profile-body` to prevent content from overlapping the profile picture and to decrease the vertical size of content boxes.

---
<a href="https://cursor.com/background-agent?bcId=bc-f11ee8c5-6924-4b14-908f-7d2a0995fe14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f11ee8c5-6924-4b14-908f-7d2a0995fe14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

