### PR TITLE
Fix guest login and remove user profile friends tab

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -319,7 +319,7 @@ export default function ProfileModal({
     }
   }, [user]);
 
-  // جلب الأصدقاء عند تغيير المستخدم أو فتح تبويب الأصدقاء
+  // جلب الأصدقاء عند تغيير المستخدم أو فتح تبويب الأصدقاء (للمستخدمين الآخرين فقط)
   useEffect(() => {
     if (localUser?.id && localUser.id !== currentUser?.id && activeTab === 'other') {
       fetchFriends(localUser.id);
@@ -2639,22 +2639,25 @@ export default function ProfileModal({
                   خيارات
                 </button>
               )}
-              <button
-                onClick={() => setActiveTab('other')}
-                style={{
-                  flex: 1,
-                  padding: '8px',
-                  background: activeTab === 'other' ? 'rgba(255,255,255,0.1)' : 'transparent',
-                  color: '#fff',
-                  border: 'none',
-                  fontSize: '14px',
-                  fontWeight: 'bold',
-                  cursor: 'pointer',
-                  transition: 'background 0.2s ease'
-                }}
-              >
-                الأصدقاء
-              </button>
+              {/* إخفاء تبويب "الأصدقاء" للمستخدم نفسه - إظهاره فقط للمستخدمين الآخرين */}
+              {localUser?.id !== currentUser?.id && (
+                <button
+                  onClick={() => setActiveTab('other')}
+                  style={{
+                    flex: 1,
+                    padding: '8px',
+                    background: activeTab === 'other' ? 'rgba(255,255,255,0.1)' : 'transparent',
+                    color: '#fff',
+                    border: 'none',
+                    fontSize: '14px',
+                    fontWeight: 'bold',
+                    cursor: 'pointer',
+                    transition: 'background 0.2s ease'
+                  }}
+                >
+                  الأصدقاء
+                </button>
+              )}
             </div>
 
             {/* Tab Content */}
@@ -3130,8 +3133,8 @@ export default function ProfileModal({
           </div>
         )}
 
-        {/* Tab Content - Other (Under Development or Friends) */}
-        {activeTab === 'other' && (
+        {/* Tab Content - Other (Friends) - فقط للمستخدمين الآخرين */}
+        {activeTab === 'other' && localUser?.id !== currentUser?.id && (
           <div style={{ 
             padding: '12px',
             borderRadius: '8px',


### PR DESCRIPTION
Hide the 'Friends' tab from the user's own profile to simplify the personal view.

This change implements the user's request to remove the 'Friends' tab specifically when a user views their own profile. The tab button, its content, and the associated data fetching logic are now conditionally rendered, appearing only when viewing another user's profile. The guest login issue was investigated and found to be working as intended, so no changes were applied to that functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0dccf8d-e7ea-4d63-82a9-cf540a4b8a59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0dccf8d-e7ea-4d63-82a9-cf540a4b8a59">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

