### PR TITLE
Customize friend tab and button for guests

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1260,34 +1260,36 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             <span className={isMobile ? 'tab-text-hide' : ''}>الغرف</span>
           </Button>
 
-          {/* الأصدقاء */}
-          <Button
-            size="sm"
-            className={`glass-effect transition-all duration-200 flex items-center gap-1.5 ${
-              isMobile ? 'flex-1 px-2 py-2 text-xs' : 'px-2 py-1.5 text-sm'
-            }${activeView === 'friends' ? ' bg-primary text-primary-foreground' : ' hover:bg-accent'} rounded-lg`}
-            onClick={() => setActiveView((prev) => (prev === 'friends' ? 'hidden' : 'friends'))}
-            title="الأصدقاء"
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              width="18"
-              height="18"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-label="Friends"
+          {/* الأصدقاء - مخفي للزوار */}
+          {chat.currentUser && chat.currentUser.userType !== 'guest' && (
+            <Button
+              size="sm"
+              className={`glass-effect transition-all duration-200 flex items-center gap-1.5 ${
+                isMobile ? 'flex-1 px-2 py-2 text-xs' : 'px-2 py-1.5 text-sm'
+              }${activeView === 'friends' ? ' bg-primary text-primary-foreground' : ' hover:bg-accent'} rounded-lg`}
+              onClick={() => setActiveView((prev) => (prev === 'friends' ? 'hidden' : 'friends'))}
+              title="الأصدقاء"
             >
-              <circle cx="9" cy="7" r="3"></circle>
-              <path d="M2 21c0-3.314 2.686-6 6-6h2c3.314 0 6 2.686 6 6"></path>
-              <path d="M19 8v6"></path>
-              <path d="M16 11h6"></path>
-            </svg>
-            <span className={isMobile ? 'tab-text-hide' : ''}>الأصدقاء</span>
-          </Button>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                width="18"
+                height="18"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-label="Friends"
+              >
+                <circle cx="9" cy="7" r="3"></circle>
+                <path d="M2 21c0-3.314 2.686-6 6-6h2c3.314 0 6 2.686 6 6"></path>
+                <path d="M19 8v6"></path>
+                <path d="M16 11h6"></path>
+              </svg>
+              <span className={isMobile ? 'tab-text-hide' : ''}>الأصدقاء</span>
+            </Button>
+          )}
         </div>
       </footer>
 

--- a/client/src/components/chat/UserContextMenu.tsx
+++ b/client/src/components/chat/UserContextMenu.tsx
@@ -336,10 +336,13 @@ export default function UserContextMenu({
             <span className="text-lg">💬 رسالة خاصة</span>
           </ContextMenuItem>
 
-          <ContextMenuItem className="flex items-center gap-3 text-green-600 font-semibold bg-green-50 hover:bg-green-100 border border-green-200 rounded-lg p-2 cursor-pointer transition-all duration-200">
-            <UserCheck className="w-5 h-5" />
-            <span className="text-lg">👥 إضافة صديق</span>
-          </ContextMenuItem>
+          {/* زر إضافة صديق - مخفي للزوار */}
+          {currentUser && currentUser.userType !== 'guest' && (
+            <ContextMenuItem className="flex items-center gap-3 text-green-600 font-semibold bg-green-50 hover:bg-green-100 border border-green-200 rounded-lg p-2 cursor-pointer transition-all duration-200">
+              <UserCheck className="w-5 h-5" />
+              <span className="text-lg">👥 إضافة صديق</span>
+            </ContextMenuItem>
+          )}
 
           <div className="my-4 border-t-2 border-border"></div>
 

--- a/client/src/components/chat/UserPopup.tsx
+++ b/client/src/components/chat/UserPopup.tsx
@@ -161,9 +161,12 @@ export default function UserPopup({
             ✉️ ارسال رسالة
           </Button>
 
-          <Button onClick={onAddFriend} variant="ghost" className="user-popup-button">
-            👥 إضافة صديق
-          </Button>
+          {/* زر إضافة صديق - مخفي للزوار */}
+          {currentUser && currentUser.userType !== 'guest' && (
+            <Button onClick={onAddFriend} variant="ghost" className="user-popup-button">
+              👥 إضافة صديق
+            </Button>
+          )}
 
           <Button onClick={onIgnore} variant="ghost" className="user-popup-button text-red-400">
             🚫 تجاهل


### PR DESCRIPTION
Hide the 'Friends' tab and 'Add Friend' buttons for guest users to restrict friend-related functionalities to registered members.

---
<a href="https://cursor.com/background-agent?bcId=bc-670ad02e-9f9f-4ac7-add4-399cc279a8b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-670ad02e-9f9f-4ac7-add4-399cc279a8b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

