### PR TITLE
Focus on friend intently

### DIFF
--- a/client/src/lib/socket.ts
+++ b/client/src/lib/socket.ts
@@ -125,7 +125,7 @@ let socketInstance: Socket | null = null;
 function getServerUrl(): string {
   try {
     const isDev = (import.meta as any)?.env?.DEV;
-    if (isDev) return 'http://localhost:5000';
+    if (isDev) return 'http://localhost:3000';
     
     // في الإنتاج، استخدم نفس الأصل دائماً
     // هذا يضمن التوافق مع أي بيئة استضافة


### PR DESCRIPTION
Update client's server URL to match the server's port.

The client was attempting to connect to `http://localhost:5000` while the server was running on `http://localhost:3000`, causing rooms and user lists to not load. This change aligns the client's connection URL with the server's actual port.

---
<a href="https://cursor.com/background-agent?bcId=bc-19fd1063-db41-4019-9148-a790a2526780">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19fd1063-db41-4019-9148-a790a2526780">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

