### PR TITLE
Analyze build output and fix story query error

### DIFF
--- a/server/routes/stories.ts
+++ b/server/routes/stories.ts
@@ -156,7 +156,9 @@ router.post('/upload', protect.member, limiters.upload, upload.single('story'), 
 router.get('/my', protect.auth, async (req, res) => {
   try {
     const userId = (req as any)?.user?.id as number;
-    if (!userId) return res.status(401).json({ error: 'غير مصرح' });
+    if (!userId || typeof userId !== 'number' || Number.isNaN(userId) || userId <= 0) {
+      return res.status(401).json({ error: 'غير مصرح' });
+    }
     const stories = await databaseService.getUserStories(userId, false);
     res.json({ success: true, stories });
   } catch (error) {
@@ -195,6 +197,10 @@ router.post('/:storyId/view', protect.auth, async (req, res) => {
 router.get('/:storyId/views', protect.auth, async (req, res) => {
   try {
     const requesterId = (req as any)?.user?.id as number;
+    if (!requesterId || typeof requesterId !== 'number' || Number.isNaN(requesterId) || requesterId <= 0) {
+      return res.status(401).json({ error: 'غير مصرح' });
+    }
+    
     const storyId = parseInt(req.params.storyId, 10);
     if (!Number.isFinite(storyId)) return res.status(400).json({ error: 'storyId غير صالح' });
 

--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -720,6 +720,13 @@ export class DatabaseService {
 
   async getUserStories(userId: number, includeExpired = false): Promise<Story[]> {
     if (!this.isConnected()) return [];
+    
+    // Defensive check: ensure userId is a valid number
+    if (!userId || typeof userId !== 'number' || Number.isNaN(userId) || userId <= 0) {
+      console.error('Error getUserStories: Invalid userId provided:', userId);
+      return [];
+    }
+    
     try {
       if (this.type === 'postgresql') {
         const now = new Date();


### PR DESCRIPTION
Add validation for `userId` in `getUserStories` and related routes to prevent database errors.

A database error occurred because a string (room ID) was incorrectly passed as an integer for the `user_id` parameter in the `getUserStories` function. This PR adds defensive checks to validate `userId` in `databaseService.ts` and the corresponding API routes, ensuring only valid numerical user IDs are used for database queries.

---
<a href="https://cursor.com/background-agent?bcId=bc-25a3f075-826f-477c-a285-39ccd812a4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-25a3f075-826f-477c-a285-39ccd812a4e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

