### PR TITLE
Analyze request deeply

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -15,6 +15,10 @@ services:
         value: production
       - key: PORT
         value: 10000
+      - key: DB_STATEMENT_TIMEOUT
+        value: 30000
+      - key: DB_IDLE_TIMEOUT
+        value: 20
       - key: ENABLE_WEBSOCKET
         value: true
       - key: SOCKET_IO_POLLING_ONLY


### PR DESCRIPTION
Re-add missing database timeout settings to `render.yaml` to fix connection issues on Render.

The `DB_STATEMENT_TIMEOUT` and `DB_IDLE_TIMEOUT` environment variables were inadvertently removed from the `render.yaml` configuration, leading to database connection failures on the deployed `arbya.chat` application. Reinstating these settings ensures proper database connectivity.

---
<a href="https://cursor.com/background-agent?bcId=bc-d590b801-2493-4207-a39f-de9936f5e82d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d590b801-2493-4207-a39f-de9936f5e82d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

