### PR TITLE
Handle vite hmr error overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,6 @@
       },
       "devDependencies": {
         "@replit/vite-plugin-cartographer": "^0.2.7",
-        "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
@@ -3893,15 +3892,6 @@
         "@babel/types": "^7.26.9",
         "magic-string": "^0.30.12",
         "modern-screenshot": "^4.6.0"
-      }
-    },
-    "node_modules/@replit/vite-plugin-runtime-error-modal": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@replit/vite-plugin-runtime-error-modal/-/vite-plugin-runtime-error-modal-0.0.3.tgz",
-      "integrity": "sha512-4wZHGuI9W4o9p8g4Ma/qj++7SP015+FMDGYobj7iap5oEsxXMm0B02TO5Y5PW8eqBPd4wX5l3UGco/hlC0qapw==",
-      "dev": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "^0.3.25"
       }
     },
     "node_modules/@rolldown/pluginutils": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,6 @@
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",
-    "@replit/vite-plugin-runtime-error-modal": "^0.0.3",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,10 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
-import runtimeErrorOverlay from '@replit/vite-plugin-runtime-error-modal';
 
 export default defineConfig({
 	plugins: [
 		react(),
-		runtimeErrorOverlay(),
 		...(process.env.NODE_ENV !== 'production' && process.env.REPL_ID !== undefined
 			? [await import('@replit/vite-plugin-cartographer').then((m) => m.cartographer())]
 			: []),
@@ -84,6 +82,10 @@ export default defineConfig({
 		fs: {
 			strict: true,
 			deny: ['**/.*', '**/node_modules/**'],
+		},
+		// Disable HMR overlay to fix runtime error modal issues
+		hmr: {
+			overlay: false,
 		},
 		// Security headers
 		headers:


### PR DESCRIPTION
Remove `@replit/vite-plugin-runtime-error-modal` and disable HMR overlay to fix runtime error modal issues.

The `@replit/vite-plugin-runtime-error-modal` plugin (version 0.0.3) was causing WebSocket communication problems and compatibility issues with Vite 6.3.5, leading to a persistent runtime error modal. Removing the plugin and explicitly disabling the HMR overlay resolves this.

---
<a href="https://cursor.com/background-agent?bcId=bc-282db482-d6fb-4d46-addf-d9c4f7aee3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-282db482-d6fb-4d46-addf-d9c4f7aee3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

