### PR TITLE
Understand user needs

### DIFF
--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -27,6 +27,9 @@ import { createUserListOptimizer, getUserListOptimizer, optimizedUserJoin, optim
 let updateQueue = new Set<string>();
 let updateTimeout: NodeJS.Timeout | null = null;
 
+// متغير لتتبع interval تحديث lastSeen
+let lastSeenUpdateInterval: NodeJS.Timeout | null = null;
+
 // ✅ دالة التحديث المجمع
 function scheduleUserListUpdate(roomId: string): void {
   updateQueue.add(roomId);


### PR DESCRIPTION
Add `lastSeenUpdateInterval` variable definition to fix server startup error.

Commit a73bb98 introduced a bug where the `lastSeenUpdateInterval` variable was not defined, causing a `ReferenceError` during server startup. This PR defines the variable to resolve the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-88e00149-03e0-436c-9e57-ea86e96d00eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88e00149-03e0-436c-9e57-ea86e96d00eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

