### PR TITLE
Remove redundant color names from settings

### DIFF
--- a/client/src/components/profile/UsernameColorPicker.tsx
+++ b/client/src/components/profile/UsernameColorPicker.tsx
@@ -120,7 +120,6 @@ export default function UsernameColorPicker({
               disabled={isLoading}
               title={colorOption.name}
             >
-              <div className="font-bold text-xs">{colorOption.name}</div>
               {selectedColor === colorOption.value && <div className="text-xs">✓</div>}
             </Button>
           ))}


### PR DESCRIPTION
Remove color names from the username color picker.

The user requested to only display the color swatches without their corresponding text names in the settings tab for username colors, aiming for a simpler and cleaner visual presentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b2baf14-d4e7-45da-898e-e3549673afbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b2baf14-d4e7-45da-898e-e3549673afbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

