### PR TITLE
Investigate transparent settings tab background

### DIFF
--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -34,7 +34,7 @@ export default function SettingsMenu({
   };
 
   return (
-    <Card className="fixed top-20 right-4 z-50 shadow-2xl animate-fade-in w-56 bg-card/95 backdrop-blur-md border-accent">
+    <Card className="fixed top-20 right-4 z-50 shadow-2xl animate-fade-in w-56 bg-card border-accent">
       <CardContent className="p-0">
         {currentUser && (
           <div className="p-3 border-b border-border" style={getUserListItemStyles(currentUser)}>


### PR DESCRIPTION
Remove transparency and blur from the settings menu background to make it solid and opaque.

The settings menu was appearing transparent due to the `bg-card/95` and `backdrop-blur-md` classes, which was not the desired behavior. This change ensures the menu has a solid background for improved readability.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4bf7f45-0365-47d2-b3f0-f226b1eba895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4bf7f45-0365-47d2-b3f0-f226b1eba895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

