### PR TITLE
Check readiness status

### DIFF
--- a/client/src/data/cityChats.ts
+++ b/client/src/data/cityChats.ts
@@ -1,3 +1,4 @@
+import { getCountryByPath } from '@/data/countryChats';
 // بيانات العواصم والمدن وروابط الشات الخاصة بكل مدينة
 export interface CityChat {
   id: string;


### PR DESCRIPTION
Add missing import for `getCountryByPath` to fix the black screen issue on city links.

The `getCountryByPath` function was being called in `client/src/data/cityChats.ts` without being imported, leading to a `ReferenceError` and a black screen when navigating to city-specific routes.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cf138a7-a8ec-44e4-834d-b5d0aa37bff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cf138a7-a8ec-44e4-834d-b5d0aa37bff9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

