### PR TITLE
Change default visitor background color to blue

### DIFF
--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -19,7 +19,7 @@ export class UserService {
         ...userData,
         role: userData.role || userData.userType || 'guest',
         profileBackgroundColor: userData.profileBackgroundColor || '#2a2a2a',
-        usernameColor: userData.usernameColor || '#000000',
+        usernameColor: userData.usernameColor || '#4A90E2',
       };
 
       const [newUser] = await db

--- a/server/utils/data-sanitizer.ts
+++ b/server/utils/data-sanitizer.ts
@@ -10,7 +10,7 @@ export function isValidHexColor(color: string): boolean {
 // دالة لتنظيف وتصحيح لون HEX
 export function sanitizeHexColor(
   color: string | null | undefined,
-  defaultColor: string = '#2a2a2a'
+  defaultColor: string = '#4A90E2'
 ): string {
   if (!color || color === 'null' || color === 'undefined' || color === '') {
     return defaultColor;
@@ -125,7 +125,7 @@ export function sanitizeUserData(user: any): any {
   return {
     ...user,
     profileBackgroundColor: sanitizeProfileBackgroundColor(user.profileBackgroundColor),
-    usernameColor: sanitizeHexColor(user.usernameColor, '#000000'),
+    usernameColor: sanitizeHexColor(user.usernameColor, '#4A90E2'),
     profileEffect: sanitizeEffect(user.profileEffect),
     dmPrivacy,
     // تفضيلات عامة (ضمان قيم منطقية افتراضية)

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -43,7 +43,7 @@ export const users = pgTable('users', {
   ipAddress: varchar('ip_address', { length: 45 }),
   deviceId: varchar('device_id', { length: 100 }),
   ignoredUsers: text('ignored_users').default('[]'), // قائمة المستخدمين المتجاهلين - JSON string للتوافق مع SQLite
-  usernameColor: text('username_color').default('#FFFFFF'), // لون اسم المستخدم
+  usernameColor: text('username_color').default('#4A90E2'), // لون اسم المستخدم (افتراضي أزرق)
   profileEffect: text('profile_effect').default('none'), // تأثير البروفايل
   points: integer('points').default(0), // نقاط المستخدم الحالية
   level: integer('level').default(1), // مستوى المستخدم
@@ -176,7 +176,7 @@ export const levelSettings = pgTable('level_settings', {
   level: integer('level').notNull().unique(),
   requiredPoints: integer('required_points').notNull(), // النقاط المطلوبة للوصول لهذا المستوى
   title: text('title').notNull(), // لقب المستوى (مبتدئ، متقدم، خبير، إلخ)
-  color: text('color').default('#FFFFFF'), // لون خاص بالمستوى
+  color: text('color').default('#4A90E2'), // لون خاص بالمستوى (افتراضي أزرق)
   benefits: jsonb('benefits'), // مزايا المستوى (JSON)
   createdAt: timestamp('created_at').defaultNow(),
 });
@@ -264,7 +264,7 @@ export const wallPosts = pgTable('wall_posts', {
   type: text('type').notNull().default('public'), // 'public', 'friends'
   timestamp: timestamp('timestamp').defaultNow(),
   userProfileImage: text('user_profile_image'),
-  usernameColor: text('username_color').default('#FFFFFF'),
+  usernameColor: text('username_color').default('#4A90E2'),
   totalLikes: integer('total_likes').default(0),
   totalDislikes: integer('total_dislikes').default(0),
   totalHearts: integer('total_hearts').default(0),


### PR DESCRIPTION
Set the default color for new users' usernames, level titles, and wall post usernames to blue (`#4A90E2`).

---
<a href="https://cursor.com/background-agent?bcId=bc-b2ed08f8-400e-4a16-899f-e414713f3480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b2ed08f8-400e-4a16-899f-e414713f3480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

