### PR TITLE
Analyze complex project for issues

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1347,6 +1347,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
           <>
             {profileUser && profileUser.id !== chat.currentUser?.id ? (
               <ProfileModal
+                key={`profile-${profileUser?.id || 'none'}`}
                 user={profileUser}
                 currentUser={chat.currentUser}
                 externalAudioManaged
@@ -1371,6 +1372,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
               />
             ) : (
               <ProfileModal
+                key={`profile-${chat.currentUser?.id || profileUser?.id || 'self'}`}
                 // مرّر نسخة حية دومًا لمستخدمك الحالي عند فتح بروفايلك
                 user={chat.currentUser || profileUser}
                 currentUser={chat.currentUser}

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1,5 +1,5 @@
 import { X } from 'lucide-react';
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useLayoutEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from '@/components/ui/dropdown-menu';
@@ -60,8 +60,8 @@ export default function ProfileModal({
   const [selectedTheme, setSelectedTheme] = useState('');
   const [selectedEffect, setSelectedEffect] = useState('none');
   
-  // تحديث فوري وقوي عند تغيير المستخدم
-  useEffect(() => {
+  // تحديث فوري وقبل الرسم عند تغيير المستخدم لمنع وميض بيانات المستخدم السابق
+  useLayoutEffect(() => {
     // إذا تغير المستخدم، نظف كل شيء فوراً
     if (currentUserId !== prevUserIdRef.current) {
       prevUserIdRef.current = currentUserId;


### PR DESCRIPTION
Add dynamic keys to `ProfileModal` and use `useLayoutEffect` for state reset to prevent profile data flickering when navigating between users.

Previously, `ProfileModal` would sometimes display old user data (like colors or images) for a brief moment when switching between profiles, especially when returning to one's own profile after viewing another. This was due to component reuse without a unique `key` and state cleanup happening *after* the initial render via `useEffect`. The changes ensure the component is fully re-rendered with fresh state and that state cleanup occurs before any visual update, eliminating the flicker.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a7cc895-3de9-41ee-b695-b5385363d759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a7cc895-3de9-41ee-b695-b5385363d759"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

