### PR TITLE
Fix walls tab image and background display

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -599,7 +599,7 @@ export default function UnifiedSidebar({
 
       {/* Walls View - تحسين التمرير */}
       {activeView === 'walls' && (
-        <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-card">
+        <div className="flex-1 overflow-hidden flex flex-col min-h-0 bg-background">
           {/* Wall Tabs */}
           <Tabs
             value={activeTab}
@@ -769,7 +769,7 @@ export default function UnifiedSidebar({
                           <img
                             src={post.imageUrl}
                             alt="Post image"
-                            className="w-full max-h-60 object-cover rounded-lg mb-3"
+                            className="w-full max-h-60 object-contain rounded-lg mb-3 bg-muted/10"
                           />
                         )}
 
@@ -882,7 +882,7 @@ export default function UnifiedSidebar({
                           <img
                             src={post.imageUrl}
                             alt="Post image"
-                            className="w-full max-h-60 object-cover rounded-lg mb-3"
+                            className="w-full max-h-60 object-contain rounded-lg mb-3 bg-muted/10"
                           />
                         )}
 

--- a/client/src/components/chat/WallPostList.tsx
+++ b/client/src/components/chat/WallPostList.tsx
@@ -134,11 +134,11 @@ export default function WallPostList({
             )}
 
             {post.imageUrl && (
-              <div className="mb-4 rounded-xl overflow-hidden bg-muted/10">
+              <div className="mb-4 rounded-xl bg-muted/10">
                 <img
                   src={post.imageUrl}
                   alt={`صورة منشور من ${post.username}`}
-                  className="w-full h-auto object-cover max-h-80 hover:scale-105 transition-transform duration-300 cursor-pointer"
+                  className="w-full h-auto object-contain max-h-[520px] cursor-pointer"
                   onClick={() => setImageLightbox({ open: true, src: post.imageUrl! })}
                 />
               </div>


### PR DESCRIPTION
Unify the walls tab background with the dark theme and fix post image rendering to display full images without cropping.

The walls tab background was `bg-card` and has been updated to `bg-background` to match the overall dark theme. Post images were `object-cover`, causing cropping; they are now `object-contain` with adjusted max heights and a subtle background to ensure full visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-40a07353-6622-45ee-a66e-c955880f395c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-40a07353-6622-45ee-a66e-c955880f395c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

