### PR TITLE
Fix room management features

### DIFF
--- a/server/routes/rooms.ts
+++ b/server/routes/rooms.ts
@@ -91,6 +91,7 @@ router.get('/stats', protect.admin, async (req, res) => {
 router.get('/', async (req, res) => {
   try {
     // 🚀 تحسينات الكاش والأداء
+    // تعطيل مؤقت للتحقق بـ ETag لأن بعض العملاء لا يتعاملون مع 304 جيداً
     const version = roomService.getRoomsVersion?.() || 1;
     const etag = `"rooms-v${version}-${Date.now() / 10000 | 0}"`; // ETag يتغير كل 10 ثواني
 
@@ -98,11 +99,7 @@ router.get('/', async (req, res) => {
     res.setHeader('Cache-Control', 'public, max-age=5, s-maxage=10, stale-while-revalidate=30');
     res.setHeader('ETag', etag);
     res.setHeader('Vary', 'Accept-Encoding'); // للتعامل مع الضغط
-    
-    // التحقق من ETag للحفظ في النطاق الترددي
-    if (req.headers['if-none-match'] === etag) {
-      return res.status(304).end();
-    }
+    // ملاحظة: لا نعيد 304 حالياً لضمان استجابة JSON كاملة للواجهة
 
     const rooms = await roomService.getAllRooms();
 


### PR DESCRIPTION
Temporarily disable ETag 304 responses for `GET /api/rooms` to fix the frontend treating 304 as an error, which caused the rooms list to appear empty and broke add/delete functionality.

The frontend's `apiRequest` function incorrectly interprets a 304 (Not Modified) response as an error, preventing the room list from being displayed or updated. This change ensures the frontend always receives a 200 OK response with the full room list, restoring functionality for adding, displaying, and deleting rooms.

---
<a href="https://cursor.com/background-agent?bcId=bc-5f80c5ed-2ad8-47a4-8b96-8a826bec8c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5f80c5ed-2ad8-47a4-8b96-8a826bec8c63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

