### PR TITLE
Fix unreliable music file deletion

### DIFF
--- a/scripts/test-profile-music-sanitizer.ts
+++ b/scripts/test-profile-music-sanitizer.ts
@@ -1,0 +1,38 @@
+import { sanitizeUserData } from '../server/utils/data-sanitizer';
+
+function assert(condition: boolean, message: string) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function run() {
+  const before = {
+    id: 1,
+    username: 'tester',
+    profileMusicUrl: '/uploads/music/music-123.mp3',
+    profileMusicTitle: 'Old Song',
+    profileMusicEnabled: true,
+    profileMusicVolume: 55,
+  } as any;
+
+  const after = {
+    ...before,
+    profileMusicUrl: null,
+    profileMusicTitle: null,
+    profileMusicEnabled: false,
+  } as any;
+
+  const sBefore = sanitizeUserData(before);
+  assert(sBefore.profileMusicUrl === '/uploads/music/music-123.mp3', 'Expected URL to be preserved before delete');
+  assert(sBefore.profileMusicEnabled === true, 'Expected music enabled before delete');
+
+  const sAfter = sanitizeUserData(after);
+  assert(typeof sAfter.profileMusicUrl === 'undefined', 'Expected URL to be undefined after delete');
+  assert(sAfter.profileMusicEnabled === false, 'Expected music disabled after delete');
+
+  console.log('✅ Sanitizer test passed: profileMusic fields cleared correctly');
+}
+
+run();
+

--- a/server/services/databaseService.ts
+++ b/server/services/databaseService.ts
@@ -313,9 +313,9 @@ export class DatabaseService {
       return null;
     }
 
-    // Filter out undefined/null values and ensure we have valid updates
+    // Filter out undefined values only; allow explicit null to clear columns
     const validUpdates = Object.fromEntries(
-      Object.entries(updates).filter(([_, value]) => value !== undefined && value !== null)
+      Object.entries(updates).filter(([_, value]) => value !== undefined)
     );
 
     // If no valid updates, return the current user without updating


### PR DESCRIPTION
Allow `null` values in user profile updates to correctly clear music fields, fixing an issue where deleted profile music persisted.

The `databaseService` was filtering out both `undefined` and `null` values during user updates. This meant that when a delete operation attempted to set `profileMusicUrl` and `profileMusicTitle` to `null` to clear them, these updates were ignored, leading to the music appearing deleted but remaining in the database and on the client. This change ensures explicit `null` values are processed, allowing fields to be properly cleared.

---
<a href="https://cursor.com/background-agent?bcId=bc-1bbdabb3-2bee-4e96-bfab-dc6e6898adbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1bbdabb3-2bee-4e96-bfab-dc6e6898adbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

