### PR TITLE
Hide loading indicator during silent login

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -8,7 +8,6 @@ import { Toaster } from '@/components/ui/toaster';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { UserProvider } from '@/contexts/UserContext';
 import { ComposerStyleProvider } from '@/contexts/ComposerStyleContext';
-import { PageLoader } from '@/components/ui/loading';
 import ChatPage from '@/pages/chat';
 import ArabicChat from '@/pages/ArabicChat';
 import CountryChat from '@/pages/CountryChat';
@@ -323,7 +322,7 @@ function App() {
               تخطِ إلى المحتوى الرئيسي
             </a>
             <main id="main-content" role="main">
-              <Suspense fallback={<PageLoader />}>
+              <Suspense fallback={null}>
                 <Router />
               </Suspense>
             </main>

--- a/client/src/components/ui/loading.tsx
+++ b/client/src/components/ui/loading.tsx
@@ -174,10 +174,7 @@ export const Loading: React.FC<LoadingProps> = ({
   return content;
 };
 
-// مؤشر تحميل الصفحة
-export const PageLoader: React.FC<{ message?: string }> = ({ message = 'جاري التحميل...' }) => (
-  <Loading fullScreen size="lg" variant="spinner" message={message} className="space-y-4" />
-);
+// تم الاستغناء عن المؤشر العام للصفحة
 
 // مؤشر تحميل الزر
 export const ButtonLoader: React.FC<{ size?: LoadingSize }> = ({ size = 'sm' }) => (

--- a/client/src/pages/CityChat.tsx
+++ b/client/src/pages/CityChat.tsx
@@ -1,4 +1,4 @@
-import { lazy, useState, useEffect } from 'react';
+import { lazy, useState, useEffect, Suspense } from 'react';
 import { useRoute, useLocation } from 'wouter';
 import { getCityByPath, CitiesSystem, getAllCities, getCitiesByCountry } from '@/data/cityChats';
 
@@ -262,15 +262,17 @@ export default function CityChat() {
   return (
     <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl" style={{ minHeight: '100dvh' }}>
 
-      {isRestoring ? (
-        <div className="p-6 text-center">...جاري استعادة الجلسة</div>
-      ) : showWelcome ? (
-        <CityWelcomeScreen onUserLogin={handleUserLogin} cityData={cityData} cityInfo={cityInfo} />
-      ) : selectedRoomId ? (
-        <ChatInterface chat={chat} onLogout={handleLogout} />
-      ) : (
-        <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
-      )}
+      <Suspense fallback={null}>
+        {isRestoring ? (
+          <div className="p-6 text-center">...جاري استعادة الجلسة</div>
+        ) : showWelcome ? (
+          <CityWelcomeScreen onUserLogin={handleUserLogin} cityData={cityData} cityInfo={cityInfo} />
+        ) : selectedRoomId ? (
+          <ChatInterface chat={chat} onLogout={handleLogout} />
+        ) : (
+          <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
+        )}
+      </Suspense>
 
       {/* Kick countdown */}
       <KickCountdown

--- a/client/src/pages/CountryChat.tsx
+++ b/client/src/pages/CountryChat.tsx
@@ -1,4 +1,4 @@
-import { lazy, useState, useEffect } from 'react';
+import { lazy, useState, useEffect, Suspense } from 'react';
 import { useRoute, useLocation } from 'wouter';
 import { getCountryByPath } from '@/data/countryChats';
 
@@ -139,15 +139,17 @@ export default function CountryChat() {
 
   return (
     <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl" style={{ minHeight: '100dvh' }}>
-      {isRestoring ? (
-        <div className="p-6 text-center">...جاري استعادة الجلسة</div>
-      ) : showWelcome ? (
-        <CountryWelcomeScreen onUserLogin={handleUserLogin} countryData={countryData} />
-      ) : selectedRoomId ? (
-        <ChatInterface chat={chat} onLogout={handleLogout} />
-      ) : (
-        <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
-      )}
+      <Suspense fallback={null}>
+        {isRestoring ? (
+          <div className="p-6 text-center">...جاري استعادة الجلسة</div>
+        ) : showWelcome ? (
+          <CountryWelcomeScreen onUserLogin={handleUserLogin} countryData={countryData} />
+        ) : selectedRoomId ? (
+          <ChatInterface chat={chat} onLogout={handleLogout} />
+        ) : (
+          <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
+        )}
+      </Suspense>
 
       {/* Kick countdown */}
       <KickCountdown

--- a/client/src/pages/SubChat.tsx
+++ b/client/src/pages/SubChat.tsx
@@ -1,4 +1,4 @@
-import { lazy, useState, useEffect } from 'react';
+import { lazy, useState, useEffect, Suspense } from 'react';
 import { useRoute, useLocation } from 'wouter';
 import { getSubChatByPath } from '@/data/subChats';
 
@@ -124,15 +124,17 @@ export default function SubChat() {
 
   return (
     <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl" style={{ minHeight: '100dvh' }}>
-      {isRestoring ? (
-        <div className="p-6 text-center">...جاري استعادة الجلسة</div>
-      ) : showWelcome ? (
-        <SubChatWelcomeScreen onUserLogin={handleUserLogin} subChatData={subChatData} />
-      ) : selectedRoomId ? (
-        <ChatInterface chat={chat} onLogout={handleLogout} />
-      ) : (
-        <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
-      )}
+      <Suspense fallback={null}>
+        {isRestoring ? (
+          <div className="p-6 text-center">...جاري استعادة الجلسة</div>
+        ) : showWelcome ? (
+          <SubChatWelcomeScreen onUserLogin={handleUserLogin} subChatData={subChatData} />
+        ) : selectedRoomId ? (
+          <ChatInterface chat={chat} onLogout={handleLogout} />
+        ) : (
+          <RoomSelectorScreen currentUser={chat.currentUser} onSelectRoom={handleSelectRoom} />
+        )}
+      </Suspense>
 
       {/* Kick countdown */}
       <KickCountdown

--- a/client/src/pages/chat.tsx
+++ b/client/src/pages/chat.tsx
@@ -131,14 +131,7 @@ export default function ChatPage() {
 
   return (
     <div className="min-h-[100dvh] bg-background text-foreground font-['Cairo'] overflow-hidden" dir="rtl" style={{ minHeight: '100dvh' }}>
-      <Suspense fallback={
-        <div className="min-h-[100dvh] bg-background text-foreground flex items-center justify-center">
-          <div className="text-center">
-            <div className="animate-spin rounded-full h-8 w-8 border-2 border-primary border-t-transparent mx-auto mb-2"></div>
-            <div>جاري التحميل...</div>
-          </div>
-        </div>
-      }>
+      <Suspense fallback={null}>
         {isRestoring ? (
           <div className="p-6 text-center">...جاري استعادة الجلسة</div>
         ) : showWelcome ? (


### PR DESCRIPTION
Hide loading indicators during silent sign-in by setting Suspense fallbacks to null in chat pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-128a6e5a-a516-469c-b1b5-579be4fe740e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-128a6e5a-a516-469c-b1b5-579be4fe740e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

