### PR TITLE
Handle room fetch and music upload errors

### DIFF
--- a/client/src/hooks/useRoomManager.ts
+++ b/client/src/hooks/useRoomManager.ts
@@ -120,7 +120,7 @@ export function useRoomManager(options: UseRoomManagerOptions = {}) {
         const response = await apiRequest('/api/rooms', {
           method: 'GET',
           // Increase timeout to better handle slow responses
-          timeout: 45000,
+          timeout: 60000,
           signal: abortControllerRef.current.signal,
         });
 


### PR DESCRIPTION
Fixes music upload 404s, improves old file deletion, corrects file size error message, and increases rooms fetch timeout.

The music upload logic now reliably moves files to the public `uploads/music` directory, preventing 404 errors for newly uploaded music. Old profile music files are also safely deleted after a successful update.

---
<a href="https://cursor.com/background-agent?bcId=bc-07dfeb84-18da-464f-a3f7-90a9201a14d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07dfeb84-18da-464f-a3f7-90a9201a14d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

