### PR TITLE
Debug music upload size limit

### DIFF
--- a/server/middleware/enhancedSecurity.ts
+++ b/server/middleware/enhancedSecurity.ts
@@ -152,7 +152,8 @@ export const requireOwnership = async (req: Request, res: Response, next: NextFu
     }
 
     // التحقق من أن المستخدم يحاول الوصول لبياناته الخاصة فقط
-    const raw = (req.params as any)?.userId || (req.params as any)?.id || ((req.body as any)?.userId);
+    // ملاحظة: لا نقرأ من req.body هنا لأنه قد لا يكون محلل بعد (خاصة مع multipart/form-data)
+    const raw = (req.params as any)?.userId || (req.params as any)?.id;
     const resourceUserId = parseEntityId(raw as any).id as number;
     const currentUserId = req.user.id;
 


### PR DESCRIPTION
Prevent 413 "Content Too Large" errors by removing premature `req.body` access in `requireOwnership` middleware.

When uploading files using `multipart/form-data`, the `requireOwnership` middleware was attempting to read `req.body.userId` before `multer` had processed the request. This caused Express to apply its default 1MB body limit, resulting in `413 Content Too Large` errors for files exceeding this size, despite `multer` and other Express configurations allowing 10MB. By removing the `req.body` access from this middleware, `multer` can now process the request correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-90565708-3c32-403a-979c-6f3c0a21a253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90565708-3c32-403a-979c-6f3c0a21a253"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

