### PR TITLE
Adjust profile card display

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1952,7 +1952,7 @@ export default function ProfileModal({
 
         .profile-card {
           width: 100%;
-          max-width: 440px;
+          max-width: 480px;
           border-radius: 16px;
           overflow: hidden;
           background: var(--card-bg);


### PR DESCRIPTION
Increase the `max-width` of the profile card to make it slightly larger.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d0623d0-57a0-4e0b-bdf6-460d69204e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d0623d0-57a0-4e0b-bdf6-460d69204e5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

