### PR TITLE
Adjust profile cover image to fill gap

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1970,7 +1970,7 @@ export default function ProfileModal({
 
         .profile-cover {
           position: relative;
-          height: 220px;
+          height: 300px;
           background-size: cover;
           background-position: center;
           background-repeat: no-repeat;


### PR DESCRIPTION
Increase profile cover height to remove the gap below it in the user profile.

---
<a href="https://cursor.com/background-agent?bcId=bc-b48a50df-c937-4549-9d62-44cac556b867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b48a50df-c937-4549-9d62-44cac556b867"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

