### PR TITLE
Check box availability status

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1765,32 +1765,16 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
       {chat.currentUser && <WelcomeNotification user={chat.currentUser} />}
 
       {/* نافذة الأثرياء */}
-      <Suspense
-        fallback={
-          <div className="fixed inset-0 z-50 flex items-center justify-center">
-            <div className="absolute inset-0 modal-overlay" />
-            <div className="relative w-[90vw] max-w-[20rem] sm:max-w-[22rem] bg-card rounded-xl overflow-hidden shadow-2xl animate-fade-in">
-              <div className="bg-primary p-3 text-primary-foreground flex items-center justify-center">
-                <div className="animate-pulse h-4 w-4 bg-primary-foreground/30 rounded mr-2" />
-                <span className="text-sm font-medium">جاري التحميل...</span>
-              </div>
-              <div className="p-3 space-y-1">
-                <div className="animate-pulse h-8 bg-muted/50 rounded" />
-                <div className="animate-pulse h-8 bg-muted/50 rounded" />
-                <div className="animate-pulse h-8 bg-muted/50 rounded" />
-                <div className="animate-pulse h-8 bg-muted/50 rounded" />
-              </div>
-            </div>
-          </div>
-        }
-      >
-        <RichestModal
-          isOpen={showRichest}
-          onClose={() => setShowRichest(false)}
-          currentUser={chat.currentUser}
-          onUserClick={(e, u) => { try { e.stopPropagation(); } catch {}; try { setShowRichest(false); } catch {}; handleViewProfile(u); }}
-        />
-      </Suspense>
+      {showRichest && (
+        <Suspense fallback={null}>
+          <RichestModal
+            isOpen={showRichest}
+            onClose={() => setShowRichest(false)}
+            currentUser={chat.currentUser}
+            onUserClick={(e, u) => { try { e.stopPropagation(); } catch {}; try { setShowRichest(false); } catch {}; handleViewProfile(u); }}
+          />
+        </Suspense>
+      )}
 
       {showIgnoredUsers && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">


### PR DESCRIPTION
Remove the loading box that appeared on page load/refresh.

The loading box for `RichestModal` was incorrectly displayed on initial page load because its `Suspense` wrapper was always rendered, even when the modal was closed. This change ensures the modal and its loading fallback (now `null`) are only rendered when `showRichest` is true.

---
<a href="https://cursor.com/background-agent?bcId=bc-b015a505-b042-41c9-b06c-20f8e87b1da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b015a505-b042-41c9-b06c-20f8e87b1da3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

