### PR TITLE
Fix user status display and setting

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -3041,9 +3041,9 @@ export default function ProfileModal({
                     fontSize: '13px',
                     fontStyle: 'italic'
                   }}
-                  title={localUser?.id === currentUser?.id ? 'اضغط لتعديل الحالة' : ''}
+                  title={localUser?.id === currentUser?.id ? (localUser?.status?.trim() ? 'اضغط لتعديل الحالة' : 'اضغط لإضافة حالة') : ''}
                 >
-                  {localUser?.status || ''}
+                  {localUser?.status?.trim() ? localUser.status : (localUser?.id === currentUser?.id ? 'اضغط لإضافة حالة' : '')}
                 </small>
               </div>
 


### PR DESCRIPTION
Add 'اضغط لإضافة حالة' prompt in ProfileModal for users without a status to enable them to set one.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e33de9d-766f-440c-a242-22c6ae8a6d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e33de9d-766f-440c-a242-22c6ae8a6d6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

