### PR TITLE
Adjust profile cover photo to fill bottom

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1976,6 +1976,20 @@ export default function ProfileModal({
           background-repeat: no-repeat;
         }
 
+        /* تمديد بصري لصورة الغلاف لأسفل لملء الفراغ قبل التبويبات */
+        .profile-cover::after {
+          content: '';
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: -28px; /* يساوي مسافة الحشو العليا في profile-body على الديسكتوب */
+          height: 28px;
+          background: inherit; /* نفس صورة الغلاف */
+          background-size: inherit;
+          background-position: inherit;
+          pointer-events: none;
+        }
+
         .change-cover-btn {
           position: absolute;
           top: 12px;
@@ -2643,6 +2657,12 @@ export default function ProfileModal({
             max-width: 100%;
           }
           
+          /* على الجوال تكون المسافة أكبر، لذا نمد الغلاف أكثر */
+          .profile-cover::after {
+            bottom: -58px;
+            height: 58px;
+          }
+
           .profile-avatar {
             width: 100px;
             height: 100px;


### PR DESCRIPTION
Extend profile cover image downwards to fill the gap above the tabs.

---
<a href="https://cursor.com/background-agent?bcId=bc-4aa7f8af-cb8e-4959-8b08-ff54228b6a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4aa7f8af-cb8e-4959-8b08-ff54228b6a8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

