### PR TITLE
Extend cover image to match bottom tabs

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -1976,6 +1976,21 @@ export default function ProfileModal({
           background-repeat: no-repeat;
         }
 
+        /* تمديد الخلفية أسفل الغلاف ليلتقي مع التبويبات بدون فراغ */
+        .profile-cover::after {
+          content: '';
+          position: absolute;
+          left: 0;
+          right: 0;
+          bottom: -28px; /* يساوي الحشوة العلوية لقسم الجسم على سطح المكتب */
+          height: 28px;
+          background: inherit;
+          background-size: inherit;
+          background-position: inherit;
+          background-repeat: inherit;
+          pointer-events: none;
+        }
+
         .change-cover-btn {
           position: absolute;
           top: 12px;
@@ -2658,6 +2673,12 @@ export default function ProfileModal({
             height: 25px;
             line-height: 25px;
             font-size: 12px;
+          }
+
+          /* على الجوال، الحشوة العلوية أكبر، لذا نمد الغلاف أكثر */
+          .profile-cover::after {
+            bottom: -58px;
+            height: 58px;
           }
           
           .profile-body {


### PR DESCRIPTION
Extend the profile cover image downwards to remove the gap between it and the bottom tabs.

This change uses a CSS pseudo-element to visually extend the cover's background, ensuring a seamless look on both desktop and mobile without affecting layout or overlays.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c3835af-0270-4629-be5f-5a25240dd77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1c3835af-0270-4629-be5f-5a25240dd77c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

