### PR TITLE
Format chat messages for phone display

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -762,7 +762,13 @@ export default function MessageArea({
 
                           <div
                             className={`runin-text text-gray-800 break-words message-content-fix`}
-                            style={{ marginRight: nameWidthMapRef.current.get(message.id) || undefined }}
+                            style={{
+                              // على الهاتف: دع الأسطر من الثانية فصاعداً تبدأ من بداية السطر (بدون هامش)
+                              // على سطح المكتب: استخدم الهامش لمحاذاة الأسطر تحت الاسم
+                              ...(isMobile
+                                ? {}
+                                : { marginRight: nameWidthMapRef.current.get(message.id) || undefined }),
+                            }}
                           >
                             {message.messageType === 'image' ? (
                               <img


### PR DESCRIPTION
Adjust multi-line message indentation on mobile to start subsequent lines from the beginning.

---
<a href="https://cursor.com/background-agent?bcId=bc-09de51a0-ee22-4a08-b304-dbbecf420f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-09de51a0-ee22-4a08-b304-dbbecf420f22"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

