### PR TITLE
Fix chat message display and wrapping

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -754,6 +754,10 @@ export default function MessageArea({
 
                           <div
                             className={`runin-text text-gray-800 break-words message-content-fix`}
+                            style={{
+                              // إزاحة ثابتة لكل الأسطر بمقدار عرض الاسم، لتبدأ الأسطر 2+ من نفس موضع السطر الأول
+                              marginRight: (nameWidthMapRef.current.get(message.id) || 0) as number,
+                            }}
                           >
                             {message.messageType === 'image' ? (
                               <img

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -754,13 +754,6 @@ export default function MessageArea({
 
                           <div
                             className={`runin-text text-gray-800 break-words message-content-fix`}
-                            style={{
-                              // على الهاتف: دع الأسطر من الثانية فصاعداً تبدأ من بداية السطر (بدون هامش)
-                              // على سطح المكتب: استخدم الهامش لمحاذاة الأسطر تحت الاسم
-                              ...(isMobile
-                                ? {}
-                                : { marginRight: nameWidthMapRef.current.get(message.id) || undefined }),
-                            }}
                           >
                             {message.messageType === 'image' ? (
                               <img

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1533,7 +1533,7 @@ li > * > div.effect-crystal {
 
 /* الاسم والشارة يوضعان في عمود مستقل ويصطفان مع أول سطر */
 .runin-name {
-  float: right;
+  float: none; /* إلغاء الالتفاف حول الاسم لضمان امتلاء الأسطر التالية كامل العرض */
   margin-left: 0.5rem; /* مسافة بين الاسم والنص */
   display: inline-flex;
   align-items: center;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1533,7 +1533,7 @@ li > * > div.effect-crystal {
 
 /* الاسم والشارة يوضعان في عمود مستقل ويصطفان مع أول سطر */
 .runin-name {
-  float: none; /* إلغاء الالتفاف حول الاسم لضمان امتلاء الأسطر التالية كامل العرض */
+  float: right; /* الاسم يبقى بمحاذاة يمين السطر الأول */
   margin-left: 0.5rem; /* مسافة بين الاسم والنص */
   display: inline-flex;
   align-items: center;
@@ -1562,7 +1562,6 @@ li > * > div.effect-crystal {
 @media (max-width: 768px) {
   .runin-text {
     text-indent: 0 !important;
-    margin-right: 0 !important;
     padding-right: 0 !important;
   }
 }


### PR DESCRIPTION
Remove dynamic `marginRight` from `runin-text` to ensure all lines of a message use the full available width.

The previous `marginRight` caused subsequent lines of text in chat messages to wrap around header elements, especially on mobile, instead of starting from the beginning of the line and filling the message bubble.

---
<a href="https://cursor.com/background-agent?bcId=bc-29d4fa92-b7de-44d5-98be-0383fb82ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-29d4fa92-b7de-44d5-98be-0383fb82ee38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

