### PR TITLE
Get ready for task

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -755,8 +755,8 @@ export default function MessageArea({
                           <div
                             className={`runin-text text-gray-800 break-words message-content-fix`}
                             style={{
-                              // إزاحة ثابتة لكل الأسطر بمقدار عرض الاسم، لتبدأ الأسطر 2+ من نفس موضع السطر الأول
-                              marginRight: (nameWidthMapRef.current.get(message.id) || 0) as number,
+                              // إزالة الإزاحة لجعل الأسطر التالية تبدأ من البداية (تحت الاسم)
+                              // marginRight: 0 - الأسطر التالية ترجع لبداية السطر
                             }}
                           >
                             {message.messageType === 'image' ? (

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1526,7 +1526,7 @@ li > * > div.effect-crystal {
   }
 }
 
-/* === محاذاة الرسائل: السطر الأول بجانب الاسم، وما بعده بعرض كامل من البداية === */
+/* === محاذاة الرسائل: السطر الأول بجانب الاسم، والأسطر التالية تبدأ من البداية (تحت الاسم) === */
 .runin-container {
   display: flow-root; /* يحتوي الـ float ويمنع تجاوز الحاوية */
 }
@@ -1546,7 +1546,7 @@ li > * > div.effect-crystal {
   padding-right: 0.25rem; /* يطابق gap المرئي ليُقاس العرض بدقة */
 }
 
-/* النص يملأ السطر التالي بالكامل بعد نهاية ارتفاع الاسم */
+/* النص: السطر الأول بجانب الاسم، والأسطر التالية تبدأ من البداية */
 .runin-text {
   display: block;
   min-width: 0;
@@ -1555,14 +1555,14 @@ li > * > div.effect-crystal {
   word-break: break-word;
   overflow-wrap: anywhere;
   white-space: pre-wrap;
-  /* عند إضافة margin-right ديناميكياً من React، سيبدأ النص تحت الاسم مباشرة */
+  /* الأسطر التالية ترجع لبداية السطر (تحت الاسم) للحصول على المظهر الطبيعي للدردشة */
 }
 
-/* إصلاح بداية الأسطر في الهاتف */
+/* إصلاح بداية الأسطر في الهاتف - تم إزالة !important المتعارض */
 @media (max-width: 768px) {
   .runin-text {
-    text-indent: 0 !important;
-    padding-right: 0 !important;
+    text-indent: 0;
+    /* تم إزالة padding-right: 0 !important لإصلاح مشكلة عرض الأسطر */
   }
 }
 


### PR DESCRIPTION
Fix multi-line chat message display to align subsequent lines under the sender's name.

The previous implementation, especially on mobile, caused multi-line messages to either indent incorrectly or start from the far left, breaking the standard chat display. This was due to a conflicting `!important` CSS rule and dynamic `marginRight` styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-519666aa-a5bd-40a8-9acd-5635bc64a093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-519666aa-a5bd-40a8-9acd-5635bc64a093"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

