### PR TITLE
Build and deploy project with errors

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -884,7 +884,6 @@ export default function MessageArea({
                           </DropdownMenuContent>
                         </DropdownMenu>
                       )}
-                    </div>
                   </>
                 )}
               </div>


### PR DESCRIPTION
Remove an extraneous `</div>` tag in `MessageArea.tsx` to fix a JSX syntax error.

The `</div>` tag at line 887 was an unexpected closing tag that did not match an opening fragment tag, causing the client-side build to fail. Removing it resolves the build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-99dc2a03-1524-4aa4-8fc3-d38a638bd962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99dc2a03-1524-4aa4-8fc3-d38a638bd962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

