### PR TITLE
Fix chat room spacing issue

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -740,7 +740,7 @@ export default function MessageArea({
                             >
                               {message.sender?.username || 'جاري التحميل...'}
                             </button>
-                            <span className="text-gray-400 mx-1">:</span>
+                            <span className="text-gray-400">:</span>
                           </div>
                           <div className="runin-text text-gray-800 message-content-fix">
                             {message.messageType === 'image' ? (
@@ -823,7 +823,7 @@ export default function MessageArea({
                             >
                               {message.sender?.username || 'جاري التحميل...'}
                             </button>
-                            <span className="text-gray-400 mx-1">:</span>
+                            <span className="text-gray-400">:</span>
                           </div>
 
                           {/* Content section - flexible width */}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1610,12 +1610,14 @@ li > * > div.effect-crystal {
   }
   .runin-name {
     display: inline;        /* الاسم inline في السطر الأول */
-    margin-left: 0.25rem;   /* مسافة صغيرة بعد الاسم */
+    margin-left: 0;         /* إزالة المسافة الزائدة */
   }
   .runin-text {
     display: inline;        /* النص يبدأ inline في نفس السطر */
     text-align: justify;    /* النص موزع بانتظام */
     line-height: 1.6;
+    margin-left: 0;         /* إزالة أي مسافة زائدة */
+    padding-left: 0;        /* إزالة أي حشو زائد */
   }
 }
 


### PR DESCRIPTION
Remove unwanted spacing between username and message content in mobile chat.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c206a59-5853-4c92-95b6-08935622517a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4c206a59-5853-4c92-95b6-08935622517a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

