### PR TITLE
Fix chat message spacing bug

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1621,6 +1621,20 @@ li > * > div.effect-crystal {
   }
 }
 
+/* إصلاح فراغ السطر الأول: تطبيع ارتفاع أيقونة الشارة داخل الاسم إلى 1em */
+.runin-name img,
+.runin-name svg {
+  height: 1em !important;         /* نفس ارتفاع النص */
+  max-height: 1em !important;
+  width: auto !important;
+  vertical-align: -0.125em;        /* تقليل هبوط خط الأساس في iOS */
+}
+
+/* منع حاوية الشارة inline-flex من تكبير line-box */
+.runin-name .inline-flex {
+  line-height: 1;                 /* صندوق الأيقونة بارتفاع محكم */
+}
+
 /* ========== MODERN ADVANCED DESIGN SYSTEM ========== */
 
 /* Modern Glass Cards */


### PR DESCRIPTION
Normalize role badge image height and alignment to fix extra vertical space in chat messages on mobile.

The extra vertical space between the first and second lines of chat messages on mobile (especially iOS) was caused by the inline role badge image increasing the `line-height` of the first line's `line-box`. This PR adjusts the badge's height to `1em` and fine-tunes its vertical alignment to prevent this expansion.

---
<a href="https://cursor.com/background-agent?bcId=bc-91e65b85-3837-4b6d-8221-1564ae2517a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-91e65b85-3837-4b6d-8221-1564ae2517a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

