### PR TITLE
Troubleshoot and understand problem cause

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1528,13 +1528,14 @@ li > * > div.effect-crystal {
 
 /* إصلاح موضع آخر كلمة في الرسائل */
 .message-content-fix {
-  line-height: 1.6;
+  line-height: 1.5;  /* تقليل line-height لتقليل التباعد */
   padding-bottom: 2px;
   padding-inline-end: 2px; /* منع قصّ آخر حرف في نهايات RTL/LTR على الهاتف */
   /* اجعل اتجاه الأساس RTL دائمًا مع عزل خلط اللغات داخل الرسالة */
   direction: rtl;
   unicode-bidi: isolate;
   text-align: start; /* يمين في RTL */
+  margin: 0;  /* إزالة أي هوامش */
 }
 
 .message-content-fix .truncate {
@@ -1603,21 +1604,27 @@ li > * > div.effect-crystal {
   white-space: pre-wrap;
 }
 
-/* تطبيق تأثير run-in محسّن للجوال */
+/* تطبيق تأثير run-in محسّن للجوال - إصلاح التباعد */
 @media (max-width: 768px) {
   .runin-container {
     position: relative;
-    line-height: 1.6;       /* توحيد line-height للحاوي */
+    line-height: 1.5;       /* تقليل line-height لتقليل التباعد */
+    display: block;
+    width: 100%;
   }
   .runin-name {
     display: inline;        /* الاسم inline في السطر الأول */
     margin-left: 0.25rem;   /* مسافة صغيرة بعد الاسم */
-    line-height: inherit;   /* وراثة line-height من الحاوي */
+    line-height: 1.5;       /* line-height ثابت ومتسق */
+    vertical-align: baseline; /* محاذاة خط الأساس */
   }
   .runin-text {
     display: inline;        /* النص يبدأ inline في نفس السطر */
     text-align: justify;    /* النص موزع بانتظام */
-    line-height: inherit;   /* وراثة line-height من الحاوي */
+    line-height: 1.5;       /* line-height ثابت ومتسق */
+    vertical-align: baseline; /* محاذاة خط الأساس */
+    margin: 0;              /* إزالة أي هوامش */
+    padding: 0;             /* إزالة أي حشو */
   }
 }
 
@@ -2500,7 +2507,7 @@ li::before {
     box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
   }
   
-  /* تحسين منطقة الرسائل للجوال */
+  /* تحسين منطقة الرسائل للجوال - إصلاح التباعد */
   .mobile-message-area {
     font-size: 14px;
   }
@@ -2509,7 +2516,7 @@ li::before {
     padding: 10px 12px;
     margin: 6px 8px;
     font-size: 14px;
-    line-height: 1.4;
+    line-height: 1.5;  /* توحيد line-height */
   }
   
   .mobile-message-area .user-img {
@@ -2574,5 +2581,36 @@ li::before {
   .mobile-message-area [data-message-type="system"] .system-message-content {
     font-size: 14px !important;
     line-height: 1.3 !important;
+  }
+
+  /* إصلاح نهائي للتباعد بين السطر الأول والثاني في الهاتف */
+  .mobile-message-area .runin-container {
+    line-height: 1.4 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+  
+  .mobile-message-area .runin-name {
+    line-height: 1.4 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    vertical-align: baseline !important;
+  }
+  
+  .mobile-message-area .runin-text {
+    line-height: 1.4 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    vertical-align: baseline !important;
+  }
+
+  /* إصلاح الأيقونات والشارات داخل الرسائل */
+  .mobile-message-area .runin-name img,
+  .mobile-message-area .runin-name svg {
+    height: 1em !important;
+    max-height: 1em !important;
+    vertical-align: -0.1em !important;
+    margin: 0 !important;
+    padding: 0 !important;
   }
 }


### PR DESCRIPTION
Fix inconsistent line spacing in mobile chat messages by unifying `line-height` and `vertical-align` properties.

The issue stemmed from conflicting `line-height` values, misaligned `vertical-align` for text elements, and extraneous margins/paddings within message containers, particularly affecting the first two lines. This PR standardizes these CSS properties and normalizes icon heights to ensure consistent message display on mobile devices.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5425131-e482-4a6b-9d17-a2e5bb4eba57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d5425131-e482-4a6b-9d17-a2e5bb4eba57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

