### PR TITLE
Fix message line spacing in phone rooms

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1608,20 +1608,25 @@ li > * > div.effect-crystal {
 @media (max-width: 768px) {
   .runin-container {
     position: relative;
-    line-height: 1.5;       /* تقليل line-height لتقليل التباعد */
+    line-height: 1.35;      /* تقليل line-height أكثر لتقليل التباعد */
     display: block;
     width: 100%;
+    margin: 0;
+    padding: 0;
   }
   .runin-name {
     display: inline;        /* الاسم inline في السطر الأول */
     margin-left: 0.25rem;   /* مسافة صغيرة بعد الاسم */
-    line-height: 1.5;       /* line-height ثابت ومتسق */
+    line-height: 1.35;      /* line-height ثابت ومتسق ومقلل */
     vertical-align: baseline; /* محاذاة خط الأساس */
+    margin-top: 0;
+    margin-bottom: 0;
+    padding: 0;
   }
   .runin-text {
     display: inline;        /* النص يبدأ inline في نفس السطر */
     text-align: justify;    /* النص موزع بانتظام */
-    line-height: 1.5;       /* line-height ثابت ومتسق */
+    line-height: 1.35;      /* line-height ثابت ومتسق ومقلل */
     vertical-align: baseline; /* محاذاة خط الأساس */
     margin: 0;              /* إزالة أي هوامش */
     padding: 0;             /* إزالة أي حشو */
@@ -1631,15 +1636,18 @@ li > * > div.effect-crystal {
 /* إصلاح فراغ السطر الأول: تطبيع ارتفاع أيقونة الشارة داخل الاسم إلى 1em */
 .runin-name img,
 .runin-name svg {
-  height: 1em !important;         /* نفس ارتفاع النص */
-  max-height: 1em !important;
+  height: 0.9em !important;       /* أصغر قليلاً من النص لتقليل التأثير على line-height */
+  max-height: 0.9em !important;
   width: auto !important;
-  vertical-align: -0.125em;        /* تقليل هبوط خط الأساس في iOS */
+  vertical-align: -0.05em;        /* تقليل هبوط خط الأساس */
 }
 
 /* منع حاوية الشارة inline-flex من تكبير line-box */
 .runin-name .inline-flex {
   line-height: 1;                 /* صندوق الأيقونة بارتفاع محكم */
+  vertical-align: baseline;       /* محاذاة خط الأساس */
+  display: inline-flex;
+  align-items: center;
 }
 
 /* ========== MODERN ADVANCED DESIGN SYSTEM ========== */
@@ -2585,32 +2593,46 @@ li::before {
 
   /* إصلاح نهائي للتباعد بين السطر الأول والثاني في الهاتف */
   .mobile-message-area .runin-container {
-    line-height: 1.4 !important;
+    line-height: 1.35 !important;
     margin: 0 !important;
     padding: 0 !important;
+    display: block !important;
+    font-size: inherit !important;
   }
   
   .mobile-message-area .runin-name {
-    line-height: 1.4 !important;
+    line-height: 1.35 !important;
     margin: 0 !important;
     padding: 0 !important;
     vertical-align: baseline !important;
+    display: inline !important;
+    font-size: inherit !important;
   }
   
   .mobile-message-area .runin-text {
-    line-height: 1.4 !important;
+    line-height: 1.35 !important;
     margin: 0 !important;
     padding: 0 !important;
     vertical-align: baseline !important;
+    display: inline !important;
+    font-size: inherit !important;
   }
 
   /* إصلاح الأيقونات والشارات داخل الرسائل */
   .mobile-message-area .runin-name img,
   .mobile-message-area .runin-name svg {
-    height: 1em !important;
-    max-height: 1em !important;
-    vertical-align: -0.1em !important;
+    height: 0.9em !important;
+    max-height: 0.9em !important;
+    vertical-align: -0.05em !important;
     margin: 0 !important;
     padding: 0 !important;
+    display: inline !important;
+  }
+
+  /* إصلاح مشكلة التباعد الإضافي بين السطور على الهاتف */
+  .mobile-message-area .runin-name *,
+  .mobile-message-area .runin-text * {
+    line-height: inherit !important;
+    vertical-align: baseline !important;
   }
 }


### PR DESCRIPTION
Adjust mobile chat message line-height and icon alignment to fix excessive spacing between the first and second lines.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b8b15d5-459b-4dfc-a179-4b6eede2d4d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0b8b15d5-459b-4dfc-a179-4b6eede2d4d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

