### PR TITLE
Investigate blank line in mobile chat messages

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -729,7 +729,7 @@ export default function MessageArea({
                     <div className={`flex-1 min-w-0`}>
                       {isMobile ? (
                         <div className="runin-container">
-                          <div className="runin-name">
+                          <span className="runin-name">
                             {message.sender && (message.sender.userType as any) !== 'bot' && (
                               <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={16} />
                             )}
@@ -741,8 +741,8 @@ export default function MessageArea({
                               {message.sender?.username || 'جاري التحميل...'}
                             </button>
                             <span className="text-gray-400 mx-1">:</span>
-                          </div>
-                          <div className="runin-text text-gray-800 message-content-fix">
+                          </span>
+                          <span className="runin-text text-gray-800 message-content-fix">
                             {message.messageType === 'image' ? (
                               <img
                                 src={message.content}
@@ -807,7 +807,7 @@ export default function MessageArea({
                                 );
                               })()
                             )}
-                          </div>
+                          </span>
                         </div>
                       ) : (
                         <div className="flex items-start gap-2">

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -453,7 +453,7 @@ export default function PrivateMessageBox({
                       <div className="flex-1 min-w-0">
                         {/* run-in on mobile; horizontal on desktop */}
                         <div className="runin-container">
-                          <div className="runin-name">
+                          <span className="runin-name">
                             <span
                               className="font-semibold text-sm"
                               style={{ color: getFinalUsernameColor(m.sender || user) }}
@@ -461,10 +461,10 @@ export default function PrivateMessageBox({
                               {m.sender?.username || (isMe ? (currentUser?.username || '') : (user.username || '')) || 'جاري التحميل...'}
                             </span>
                             <span className="text-gray-400 mx-1">:</span>
-                          </div>
+                          </span>
 
                           {/* Content section - full width under the name (mobile), inline on first line */}
-                          <div className="runin-text text-gray-800 break-words message-content-fix">
+                          <span className="runin-text text-gray-800 break-words message-content-fix">
                           {hasStoryContext && (
                             <div className="mb-2">
                               <div className="flex items-center gap-3 p-2 rounded-lg border bg-gradient-to-r from-purple-50 to-pink-50 border-purple-200">
@@ -560,7 +560,7 @@ export default function PrivateMessageBox({
                               </span>
                             );
                           })()}
-                          </div>
+                          </span>
 
                           {/* Time section - fixed width */}
                           <span className="text-xs text-gray-500 whitespace-nowrap shrink-0 self-start">

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1528,20 +1528,20 @@ li > * > div.effect-crystal {
 
 /* إصلاح موضع آخر كلمة في الرسائل */
 .message-content-fix {
-  line-height: 1.5;  /* تقليل line-height لتقليل التباعد */
-  padding-bottom: 2px;
-  padding-inline-end: 2px; /* منع قصّ آخر حرف في نهايات RTL/LTR على الهاتف */
+  line-height: 1.4;  /* line-height متسق مع الحاوي */
+  padding: 0;       /* إزالة جميع الحشو */
+  margin: 0;        /* إزالة جميع الهوامش */
   /* اجعل اتجاه الأساس RTL دائمًا مع عزل خلط اللغات داخل الرسالة */
   direction: rtl;
   unicode-bidi: isolate;
   text-align: start; /* يمين في RTL */
-  margin: 0;  /* إزالة أي هوامش */
 }
 
 .message-content-fix .truncate {
   line-height: inherit;
   vertical-align: baseline;
-  margin-bottom: 1px;
+  margin: 0;
+  padding: 0;
 }
 
 /* أنماط السمايلات المتحركة */
@@ -1608,7 +1608,7 @@ li > * > div.effect-crystal {
 @media (max-width: 768px) {
   .runin-container {
     position: relative;
-    line-height: 1.35;      /* تقليل line-height أكثر لتقليل التباعد */
+    line-height: 1.4;       /* line-height طبيعي ومتسق */
     display: block;
     width: 100%;
     margin: 0;
@@ -1617,7 +1617,7 @@ li > * > div.effect-crystal {
   .runin-name {
     display: inline;        /* الاسم inline في السطر الأول */
     margin-left: 0.25rem;   /* مسافة صغيرة بعد الاسم */
-    line-height: 1.35;      /* line-height ثابت ومتسق ومقلل */
+    line-height: inherit;   /* وراثة line-height من الحاوي */
     vertical-align: baseline; /* محاذاة خط الأساس */
     margin-top: 0;
     margin-bottom: 0;
@@ -1625,8 +1625,8 @@ li > * > div.effect-crystal {
   }
   .runin-text {
     display: inline;        /* النص يبدأ inline في نفس السطر */
-    text-align: justify;    /* النص موزع بانتظام */
-    line-height: 1.35;      /* line-height ثابت ومتسق ومقلل */
+    text-align: start;      /* محاذاة طبيعية */
+    line-height: inherit;   /* وراثة line-height من الحاوي */
     vertical-align: baseline; /* محاذاة خط الأساس */
     margin: 0;              /* إزالة أي هوامش */
     padding: 0;             /* إزالة أي حشو */
@@ -2593,7 +2593,7 @@ li::before {
 
   /* إصلاح نهائي للتباعد بين السطر الأول والثاني في الهاتف */
   .mobile-message-area .runin-container {
-    line-height: 1.35 !important;
+    line-height: 1.4 !important;
     margin: 0 !important;
     padding: 0 !important;
     display: block !important;
@@ -2601,16 +2601,17 @@ li::before {
   }
   
   .mobile-message-area .runin-name {
-    line-height: 1.35 !important;
+    line-height: inherit !important;
     margin: 0 !important;
     padding: 0 !important;
     vertical-align: baseline !important;
     display: inline !important;
     font-size: inherit !important;
+    margin-left: 0.25rem !important;
   }
   
   .mobile-message-area .runin-text {
-    line-height: 1.35 !important;
+    line-height: inherit !important;
     margin: 0 !important;
     padding: 0 !important;
     vertical-align: baseline !important;
@@ -2634,5 +2635,22 @@ li::before {
   .mobile-message-area .runin-text * {
     line-height: inherit !important;
     vertical-align: baseline !important;
+  }
+
+  /* إزالة أي مسافات إضافية قد تسبب سطر فارغ */
+  .mobile-message-area .runin-container::before,
+  .mobile-message-area .runin-container::after,
+  .mobile-message-area .runin-name::before,
+  .mobile-message-area .runin-name::after,
+  .mobile-message-area .runin-text::before,
+  .mobile-message-area .runin-text::after {
+    content: none !important;
+    display: none !important;
+  }
+
+  /* إزالة أي فواصل أسطر غير مرغوب فيها */
+  .mobile-message-area .runin-name br,
+  .mobile-message-area .runin-text br {
+    display: none !important;
   }
 }


### PR DESCRIPTION
Fixes an extra blank line appearing in mobile chat messages by adjusting element types and refining CSS spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-ec695c1e-7947-4668-a75b-725cc8d89261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ec695c1e-7947-4668-a75b-725cc8d89261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

