### PR TITLE
Debug empty line in mobile chat

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2622,7 +2622,7 @@ li::before {
     line-height: 1.4 !important;
     margin: 0 !important;
     padding: 0 !important;
-    display: contents !important; /* استخدام contents لإزالة الحاوي من التخطيط */
+    display: block !important; /* تغيير من contents إلى block لإزالة الفراغ */
     font-size: inherit !important;
   }
   
@@ -2635,6 +2635,7 @@ li::before {
     font-size: inherit !important;
     margin-left: 0.25rem !important;
     white-space: nowrap !important; /* منع التفاف الاسم */
+    margin-bottom: 0 !important; /* منع أي هامش سفلي */
   }
   
   .mobile-message-area .runin-text {
@@ -2645,6 +2646,7 @@ li::before {
     display: inline !important;
     font-size: inherit !important;
     white-space: pre-wrap !important; /* السماح بفواصل الأسطر الطبيعية فقط */
+    margin-top: 0 !important; /* منع أي هامش علوي */
   }
 
   /* إصلاح الأيقونات والشارات داخل الرسائل */


### PR DESCRIPTION
Fix an extra empty line appearing between the first and second lines of chat messages on mobile.

The `display: contents` property on the `runin-container` in mobile chat was causing an unwanted line break between the user's name/first part of the message and the subsequent message text. Changing it to `display: block` and resetting margins ensures correct line spacing.

---
<a href="https://cursor.com/background-agent?bcId=bc-6cda843b-3634-47fc-be76-235c8e4f9b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6cda843b-3634-47fc-be76-235c8e4f9b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

