### PR TITLE
Improve room chat functionality

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1230,12 +1230,7 @@ export default function MessageArea({
           )}
         </div>
 
-        {/* Character Counter */}
-        {messageText.length > 0 && (
-          <div className="mt-1 text-[11px] text-gray-500 text-left">
-            {messageText.length}/{MAX_CHARS} حرف
-          </div>
-        )}
+        {/* Character Counter - تم إخفاء العرض مع الاحتفاظ بالوظيفة */}
       </div>
     </section>
   );


### PR DESCRIPTION
Remove character count display from public chat rooms while retaining the underlying character limit functionality.

---
<a href="https://cursor.com/background-agent?bcId=bc-8ab77c8e-e4ab-4b36-8f3f-27da3594ba55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8ab77c8e-e4ab-4b36-8f3f-27da3594ba55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

