### PR TITLE
Optimize mobile chat display for full line utilization

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -559,36 +559,69 @@ export default function MessageArea({
                       </div>
                     )}
                     <div className={`flex-1 min-w-0`}>
-                      {/* Unified layout for both mobile and desktop */}
-                      <div className={`flex items-start gap-2 ${isMobile ? 'system-message-mobile' : ''}`}>
-                        {/* Name and badge section - fixed width */}
-                        <div className="flex items-center gap-1 shrink-0">
-                          {message.sender && (message.sender.userType as any) !== 'bot' && (
-                            <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={16} />
-                          )}
-                          <button
-                            onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
-                            className="font-semibold hover:underline transition-colors duration-200 text-sm"
-                            style={{ color: getFinalUsernameColor(message.sender) }}
-                          >
-                            {message.sender?.username || 'جاري التحميل...'}
-                          </button>
-                          <span className="text-red-400 mx-1">:</span>
-                        </div>
-
-                        {/* Content section - flexible width */}
-                        <div className={`flex-1 min-w-0 text-red-600 break-words message-content-fix ${isMobile ? 'system-message-content' : ''}`}>
-                          <span className={isMobile ? '' : 'line-clamp-2'}>
+                      {/* Mobile run-in layout to fully utilize line width */}
+                      {isMobile ? (
+                        <div className="mobile-message-optimized">
+                          <span className="mobile-name-inline">
+                            {message.sender && (message.sender.userType as any) !== 'bot' && (
+                              <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={14} />
+                            )}
+                            <button
+                              onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                              className="font-semibold hover:underline transition-colors duration-200"
+                              style={{ 
+                                color: getFinalUsernameColor(message.sender),
+                                fontSize: '14px',
+                                lineHeight: '1.35'
+                              }}
+                            >
+                              {message.sender?.username || 'جاري التحميل...'}
+                            </button>
+                            <span className="text-red-400" style={{ margin: '0 2px' }}>:</span>
+                          </span>
+                          <span className="mobile-text-flow message-content-fix system-message-content text-red-600">
                             {message.content}
                           </span>
+                          <div className="mobile-meta-row">
+                            <span className="text-xs text-red-500 whitespace-nowrap">
+                              {formatTime(message.timestamp)}
+                            </span>
+                          </div>
                         </div>
-                      </div>
+                      ) : (
+                        /* Desktop: keep horizontal layout with fixed name column */
+                        <div className={`flex items-start gap-2`}>
+                          {/* Name and badge section - fixed width */}
+                          <div className="flex items-center gap-1 shrink-0">
+                            {message.sender && (message.sender.userType as any) !== 'bot' && (
+                              <UserRoleBadge user={message.sender} showOnlyIcon={true} hideGuestAndGender={true} size={16} />
+                            )}
+                            <button
+                              onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                              className="font-semibold hover:underline transition-colors duration-200 text-sm"
+                              style={{ color: getFinalUsernameColor(message.sender) }}
+                            >
+                              {message.sender?.username || 'جاري التحميل...'}
+                            </button>
+                            <span className="text-red-400 mx-1">:</span>
+                          </div>
+
+                          {/* Content section - flexible width */}
+                          <div className={`flex-1 min-w-0 text-red-600 break-words message-content-fix`}>
+                            <span className={'line-clamp-2'}>
+                              {message.content}
+                            </span>
+                          </div>
+                        </div>
+                      )}
                     </div>
 
-                    {/* Right side: time */}
-                    <span className="text-xs text-red-500 whitespace-nowrap ml-2 self-start">
-                      {formatTime(message.timestamp)}
-                    </span>
+                    {/* Right side: time (desktop only) */}
+                    {!isMobile && (
+                      <span className="text-xs text-red-500 whitespace-nowrap ml-2 self-start">
+                        {formatTime(message.timestamp)}
+                      </span>
+                    )}
                   </>
                 ) : (
                   <>
@@ -682,6 +715,78 @@ export default function MessageArea({
                               })()
                             )}
                           </span>
+                          {/* Mobile-only meta row: time + menu below content to free full width */}
+                          <div className="mobile-meta-row">
+                            <span className="text-xs text-gray-500 whitespace-nowrap">
+                              {formatTime(message.timestamp)}
+                            </span>
+                            {currentUser && (
+                              <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                  <button
+                                    className="h-6 w-6 p-0 text-gray-600 hover:text-gray-900"
+                                    title="المزيد"
+                                    aria-label="المزيد"
+                                  >
+                                    <MoreVertical className="w-4 h-4" />
+                                  </button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start" sideOffset={6} className="min-w-[180px]">
+                                  {/* Reactions */}
+                                  {!message.isPrivate && (["like","dislike","heart"] as const).map((r) => {
+                                    const isMine = message.myReaction === r;
+                                    const count = message.reactions?.[r] ?? 0;
+                                    const label = r === 'like' ? '👍 إعجاب' : r === 'dislike' ? '👎 عدم إعجاب' : '❤️ قلب';
+                                    const toggle = async () => {
+                                      try {
+                                        if (isMine) {
+                                          await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'DELETE' });
+                                        } else {
+                                          await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'POST', body: { type: r } });
+                                        }
+                                      } catch (e) {
+                                        console.error('reaction error', e);
+                                      }
+                                    };
+                                    return (
+                                      <DropdownMenuItem key={r} onClick={toggle} className={`flex items-center justify-between gap-2 ${isMine ? 'text-primary' : ''}`}>
+                                        <span>{label}</span>
+                                        <span className="text-xs text-gray-500">{count}</span>
+                                      </DropdownMenuItem>
+                                    );
+                                  })}
+                                  {/* Report */}
+                                  {onReportMessage && message.sender && currentUser && message.sender.id !== currentUser.id && (
+                                    <DropdownMenuItem onClick={() => onReportMessage(message.sender!, message.content, message.id)}>
+                                      🚩 تبليغ
+                                    </DropdownMenuItem>
+                                  )}
+                                  {/* Delete */}
+                                  {(() => {
+                                    if (!message.sender || !currentUser) return null;
+                                    const isOwner = currentUser.userType === 'owner';
+                                    const isAdmin = currentUser.userType === 'admin';
+                                    const isSender = currentUser.id === message.sender.id;
+                                    const canDelete = isSender || isOwner || isAdmin;
+                                    if (!canDelete) return null;
+                                    const handleDelete = async () => {
+                                      try {
+                                        await apiRequest(`/api/messages/${message.id}`, {
+                                          method: 'DELETE',
+                                          body: { userId: currentUser.id, roomId: message.roomId || 'general' },
+                                        });
+                                      } catch (e) {
+                                        console.error('خطأ في حذف الرسالة', e);
+                                      }
+                                    };
+                                    return (
+                                      <DropdownMenuItem onClick={handleDelete}>🗑️ حذف</DropdownMenuItem>
+                                    );
+                                  })()}
+                                </DropdownMenuContent>
+                              </DropdownMenu>
+                            )}
+                          </div>
                         </div>
                       ) : (
                         <div className="flex items-start gap-2">
@@ -771,77 +876,79 @@ export default function MessageArea({
                       )}
                     </div>
 
-                      {/* Right side: time */}
-                      <span className="text-xs text-gray-500 whitespace-nowrap ml-2 self-start">
-                        {formatTime(message.timestamp)}
-                      </span>
-
-                      {/* قائمة ثلاث نقاط موحدة للجوال وسطح المكتب */}
-                      {currentUser && (
-                        <DropdownMenu>
-                          <DropdownMenuTrigger asChild>
-                            <button
-                              className="h-6 w-6 p-0 text-gray-600 hover:text-gray-900 self-start ml-1"
-                              title="المزيد"
-                              aria-label="المزيد"
-                            >
-                              <MoreVertical className="w-4 h-4" />
-                            </button>
-                          </DropdownMenuTrigger>
-                          <DropdownMenuContent align="start" sideOffset={6} className="min-w-[180px]">
-                            {/* Reactions */}
-                            {!message.isPrivate && (["like","dislike","heart"] as const).map((r) => {
-                              const isMine = message.myReaction === r;
-                              const count = message.reactions?.[r] ?? 0;
-                              const label = r === 'like' ? '👍 إعجاب' : r === 'dislike' ? '👎 عدم إعجاب' : '❤️ قلب';
-                              const toggle = async () => {
-                                try {
-                                  if (isMine) {
-                                    await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'DELETE' });
-                                  } else {
-                                    await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'POST', body: { type: r } });
-                                  }
-                                } catch (e) {
-                                  console.error('reaction error', e);
-                                }
-                              };
-                              return (
-                                <DropdownMenuItem key={r} onClick={toggle} className={`flex items-center justify-between gap-2 ${isMine ? 'text-primary' : ''}`}>
-                                  <span>{label}</span>
-                                  <span className="text-xs text-gray-500">{count}</span>
-                                </DropdownMenuItem>
-                              );
-                            })}
-                            {/* Report */}
-                            {onReportMessage && message.sender && currentUser && message.sender.id !== currentUser.id && (
-                              <DropdownMenuItem onClick={() => onReportMessage(message.sender!, message.content, message.id)}>
-                                🚩 تبليغ
-                              </DropdownMenuItem>
-                            )}
-                            {/* Delete */}
-                            {(() => {
-                              if (!message.sender || !currentUser) return null;
-                              const isOwner = currentUser.userType === 'owner';
-                              const isAdmin = currentUser.userType === 'admin';
-                              const isSender = currentUser.id === message.sender.id;
-                              const canDelete = isSender || isOwner || isAdmin;
-                              if (!canDelete) return null;
-                              const handleDelete = async () => {
-                                try {
-                                  await apiRequest(`/api/messages/${message.id}`, {
-                                    method: 'DELETE',
-                                    body: { userId: currentUser.id, roomId: message.roomId || 'general' },
-                                  });
-                                } catch (e) {
-                                  console.error('خطأ في حذف الرسالة', e);
-                                }
-                              };
-                              return (
-                                <DropdownMenuItem onClick={handleDelete}>🗑️ حذف</DropdownMenuItem>
-                              );
-                            })()}
-                          </DropdownMenuContent>
-                        </DropdownMenu>
+                      {/* Right side: time + menu (desktop only) */}
+                      {!isMobile && (
+                        <>
+                          <span className="text-xs text-gray-500 whitespace-nowrap ml-2 self-start">
+                            {formatTime(message.timestamp)}
+                          </span>
+                          {currentUser && (
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <button
+                                  className="h-6 w-6 p-0 text-gray-600 hover:text-gray-900 self-start ml-1"
+                                  title="المزيد"
+                                  aria-label="المزيد"
+                                >
+                                  <MoreVertical className="w-4 h-4" />
+                                </button>
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent align="start" sideOffset={6} className="min-w-[180px]">
+                                {/* Reactions */}
+                                {!message.isPrivate && (["like","dislike","heart"] as const).map((r) => {
+                                  const isMine = message.myReaction === r;
+                                  const count = message.reactions?.[r] ?? 0;
+                                  const label = r === 'like' ? '👍 إعجاب' : r === 'dislike' ? '👎 عدم إعجاب' : '❤️ قلب';
+                                  const toggle = async () => {
+                                    try {
+                                      if (isMine) {
+                                        await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'DELETE' });
+                                      } else {
+                                        await apiRequest(`/api/messages/${message.id}/reactions`, { method: 'POST', body: { type: r } });
+                                      }
+                                    } catch (e) {
+                                      console.error('reaction error', e);
+                                    }
+                                  };
+                                  return (
+                                    <DropdownMenuItem key={r} onClick={toggle} className={`flex items-center justify-between gap-2 ${isMine ? 'text-primary' : ''}`}>
+                                      <span>{label}</span>
+                                      <span className="text-xs text-gray-500">{count}</span>
+                                    </DropdownMenuItem>
+                                  );
+                                })}
+                                {/* Report */}
+                                {onReportMessage && message.sender && currentUser && message.sender.id !== currentUser.id && (
+                                  <DropdownMenuItem onClick={() => onReportMessage(message.sender!, message.content, message.id)}>
+                                    🚩 تبليغ
+                                  </DropdownMenuItem>
+                                )}
+                                {/* Delete */}
+                                {(() => {
+                                  if (!message.sender || !currentUser) return null;
+                                  const isOwner = currentUser.userType === 'owner';
+                                  const isAdmin = currentUser.userType === 'admin';
+                                  const isSender = currentUser.id === message.sender.id;
+                                  const canDelete = isSender || isOwner || isAdmin;
+                                  if (!canDelete) return null;
+                                  const handleDelete = async () => {
+                                    try {
+                                      await apiRequest(`/api/messages/${message.id}`, {
+                                        method: 'DELETE',
+                                        body: { userId: currentUser.id, roomId: message.roomId || 'general' },
+                                      });
+                                    } catch (e) {
+                                      console.error('خطأ في حذف الرسالة', e);
+                                    }
+                                  };
+                                  return (
+                                    <DropdownMenuItem onClick={handleDelete}>🗑️ حذف</DropdownMenuItem>
+                                  );
+                                })()}
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          )}
+                        </>
                       )}
                   </>
                 )}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1656,6 +1656,14 @@ li > * > div.effect-crystal {
     height: auto;
     vertical-align: middle;
   }
+
+  /* صف ميتا تحت النص لتوسيع عرض السطر الأول بالكامل */
+  .mobile-meta-row {
+    display: flex !important;
+    align-items: center;
+    gap: 8px;
+    margin-top: 4px;
+  }
   
   /* تحسين عرض أزرار اليوتيوب */
   .mobile-message-optimized button {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Restructure mobile chat message layout to fully utilize line width by moving meta information below the content and ensuring the first line next to the username flows naturally.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous mobile layout did not fully utilize the available screen width for message content, as the time and "more" menu occupied horizontal space next to the message. This led to inefficient space usage and inconsistent text wrapping. This change addresses these issues by stacking meta information and allowing the message text to span the full width.

---
<a href="https://cursor.com/background-agent?bcId=bc-f55928e4-54bd-4ae2-9bd3-02d7c82b2efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f55928e4-54bd-4ae2-9bd3-02d7c82b2efa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

