### PR TITLE
Adjust chat spacing and display for mobile

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -571,13 +571,13 @@ export default function MessageArea({
                               className="font-semibold hover:underline transition-colors duration-200"
                               style={{ 
                                 color: getFinalUsernameColor(message.sender),
-                                fontSize: '14px',
-                                lineHeight: '1.35'
+                                fontSize: '15px',
+                                lineHeight: '1.3'
                               }}
                             >
                               {message.sender?.username || 'جاري التحميل...'}
                             </button>
-                            <span className="text-red-400" style={{ margin: '0 2px' }}>:</span>
+                            <span className="text-red-400" style={{ margin: '0 1px' }}>:</span>
                           </span>
                           <span className="mobile-text-flow message-content-fix system-message-content text-red-600">
                             {message.content}
@@ -651,13 +651,13 @@ export default function MessageArea({
                               className="font-semibold hover:underline transition-colors duration-200"
                               style={{ 
                                 color: getFinalUsernameColor(message.sender),
-                                fontSize: '14px',
-                                lineHeight: '1.35'
+                                fontSize: '15px',
+                                lineHeight: '1.3'
                               }}
                             >
                               {message.sender?.username || 'جاري التحميل...'}
                             </button>
-                            <span className="text-gray-400" style={{ margin: '0 2px' }}>:</span>
+                            <span className="text-gray-400" style={{ margin: '0 1px' }}>:</span>
                           </span>
                           {/* النص يكمل في نفس السطر ثم ينتقل للأسطر التالية */}
                           <span 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1585,7 +1585,7 @@ li > * > div.effect-crystal {
   display: block;
   width: 100%;
   font-size: 15px !important;
-  line-height: 1.35 !important; /* مضغوط للاستغلال الأمثل */
+  line-height: 1.3 !important; /* مضغوط للاستغلال الأمثل */
   word-break: break-word;
   overflow-wrap: break-word;
   hyphens: auto;
@@ -1598,8 +1598,8 @@ li > * > div.effect-crystal {
 .mobile-name-inline {
   display: inline;
   font-weight: 600;
-  font-size: 14px;
-  line-height: 1.35;
+  font-size: 15px;
+  line-height: 1.3;
   margin-left: 4px;
   white-space: nowrap;
 }
@@ -1608,7 +1608,7 @@ li > * > div.effect-crystal {
 .mobile-text-flow {
   display: inline;
   font-size: 15px;
-  line-height: 1.35;
+  line-height: 1.3;
   word-spacing: -0.5px; /* تقليل المسافة بين الكلمات لتوفير مساحة */
   letter-spacing: -0.2px; /* تقليل المسافة بين الأحرف */
 }
@@ -1674,6 +1674,17 @@ li > * > div.effect-crystal {
   /* ضمان عدم كسر التخطيط */
   .mobile-message-optimized * {
     box-sizing: border-box;
+  }
+
+  /* محاذاة مثالية لأساس السطر لعناصر الاسم والنص */
+  .mobile-message-area .mobile-name-inline *,
+  .mobile-message-area .mobile-text-flow * {
+    vertical-align: baseline !important;
+  }
+
+  /* تقليل المسافة بين الأسطر لرسائل النظام على الجوال */
+  .mobile-message-area .message-content-fix {
+    line-height: 1.3 !important;
   }
 }
 


### PR DESCRIPTION
Adjust mobile chat message layout to reduce spacing and align wrapped text directly under the username.

The user reported excessive vertical spacing between the username and the message content on mobile, particularly when the message wrapped to a second line. This PR tightens line height, unifies font sizes, and enforces baseline alignment to ensure message text flows seamlessly from directly below the username.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9e9edb9-fcd1-425d-aee4-b71f8ed6568f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b9e9edb9-fcd1-425d-aee4-b71f8ed6568f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

