### PR TITLE
Image understanding and processing

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1610,14 +1610,33 @@ li > * > div.effect-crystal {
     line-height: 1.6; /* توحيد line-height للحاوي الكامل */
   }
   .runin-name {
-    display: inline;        /* الاسم inline في السطر الأول */
-    margin-left: 0.25rem;   /* مسافة صغيرة بعد الاسم */
-    line-height: inherit;   /* وراثة line-height من الحاوي */
+    display: inline;              /* الاسم inline في السطر الأول */
+    margin-left: 0.25rem;         /* مسافة صغيرة بعد الاسم */
+    line-height: inherit;         /* وراثة line-height من الحاوي */
+    vertical-align: baseline;     /* تثبيت المحاذاة */
   }
   .runin-text {
-    display: inline;        /* النص يبدأ inline في نفس السطر */
-    text-align: justify;    /* النص موزع بانتظام */
-    line-height: inherit;   /* وراثة line-height من الحاوي */
+    display: inline;              /* النص يبدأ inline في نفس السطر */
+    text-align: justify;          /* النص موزع بانتظام */
+    line-height: inherit;         /* وراثة line-height من الحاوي */
+  }
+
+  /* إصلاح فراغ السطر الأول على الهاتف: قياس الأيقونات داخل الاسم إلى 1em
+     ومنع inline-flex من تكبير line-box للسطر الأول */
+  .runin-container .runin-name span.inline-flex {
+    display: inline-block !important;
+    line-height: 1 !important;
+    height: 1em !important;
+    vertical-align: -0.15em !important;
+  }
+  .runin-container .runin-name img,
+  .runin-container .runin-name svg,
+  .runin-container .runin-name .emoji {
+    display: inline-block;
+    height: 1em !important;
+    width: auto !important;
+    line-height: 1 !important;
+    vertical-align: -0.15em !important;
   }
 }
 


### PR DESCRIPTION
Remove the extra vertical gap between the first and second lines of chat messages on mobile by standardizing icon sizing and alignment within the sender's name.

The first line of chat messages on mobile devices had an increased line-box height due to embedded icons (e.g., rank icons, emojis) within the sender's name. This caused an unwanted vertical gap before the second line of text. This PR adjusts the CSS for these inline elements to ensure they do not disproportionately affect the line height, thus removing the visual gap.

---
<a href="https://cursor.com/background-agent?bcId=bc-f609cfe6-946b-4ad2-afdb-8f7f1003413e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f609cfe6-946b-4ad2-afdb-8f7f1003413e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

