### PR TITLE
Debug mobile chat line spacing issue

### DIFF
--- a/client/src/components/chat/UserRoleBadge.tsx
+++ b/client/src/components/chat/UserRoleBadge.tsx
@@ -54,51 +54,45 @@ export function getUserLevelIcon(user: ChatUser, size: number = 20): JSX.Element
 
   // owner: تاج SVG مع fallback
   if (user.userType === 'owner') {
-    const w = size * 1.15;
-    const h = size * 1.15;
     return (
       <img
         src="/svgs/crown.svg"
         alt="owner"
-        style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+        style={{ width: '1.15em', height: '1.15em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
         onError={(e) => {
           const target = e.target as HTMLImageElement;
           target.style.display = 'none';
-          target.outerHTML = '<span style="font-size: ' + Math.max(w, h) + 'px; display: inline;">👑</span>';
+          target.outerHTML = '<span style="font-size: 1em; display: inline;">👑</span>';
         }}
       />
     );
   }
   // admin: نجمة
   if (user.userType === 'admin') {
-    const w = size;
-    const h = size;
     return (
       <img
         src="/svgs/star.svg"
         alt="admin"
-        style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+        style={{ width: '1em', height: '1em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
         onError={(e) => {
           const target = e.target as HTMLImageElement;
           target.style.display = 'none';
-          target.outerHTML = '<span style="font-size: ' + Math.max(w, h) + 'px; display: inline;">⭐</span>';
+          target.outerHTML = '<span style="font-size: 1em; display: inline;">⭐</span>';
         }}
       />
     );
   }
   // moderator: درع
   if (user.userType === 'moderator') {
-    const w = size;
-    const h = size;
     return (
       <img
         src="/svgs/moderator_shield.svg"
         alt="moderator"
-        style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+        style={{ width: '1em', height: '1em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
         onError={(e) => {
           const target = e.target as HTMLImageElement;
           target.style.display = 'none';
-          target.outerHTML = '<span style="font-size: ' + Math.max(w, h) + 'px; display: inline;">🛡️</span>';
+          target.outerHTML = '<span style="font-size: 1em; display: inline;">🛡️</span>';
         }}
       />
     );
@@ -111,85 +105,75 @@ export function getUserLevelIcon(user: ChatUser, size: number = 20): JSX.Element
 
     // عضو ذكر لفل 1-10: سهم أزرق
     if (level >= 1 && level <= 10 && gender === 'male') {
-      const w = size * 1.15; // تعريض بسيط
-      const h = size;
       return (
         <img
           src="/svgs/blue_arrow.svg"
           alt="male-lvl1-10"
-          style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+          style={{ width: '1.15em', height: '1em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
           onError={(e) => {
             const target = e.target as HTMLImageElement;
             target.outerHTML =
-              '<span style="color: #3b82f6; font-size: ' + Math.max(w, h) + 'px; display: inline;">↗️</span>';
+              '<span style="color: #3b82f6; font-size: 1em; display: inline;">↗️</span>';
           }}
         />
       );
     }
     // عضو أنثى لفل 1-10: ميدالية وردية
     if (level >= 1 && level <= 10 && gender === 'female') {
-      const w = size * 1.15; // تعريض بسيط
-      const h = size;
       return (
         <img
           src="/svgs/pink_medal.svg"
           alt="female-lvl1-10"
-          style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+          style={{ width: '1.15em', height: '1em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
           onError={(e) => {
             const target = e.target as HTMLImageElement;
             target.outerHTML =
-              '<span style="color: #ec4899; font-size: ' + Math.max(w, h) + 'px; display: inline;">🏅</span>';
+              '<span style="color: #ec4899; font-size: 1em; display: inline;">🏅</span>';
           }}
         />
       );
     }
     // عضو لفل 11-20: ألماسة بيضاء
     if (level >= 11 && level <= 20) {
-      const w = size;
-      const h = size * 0.85; // تقصير بالطول فقط
       return (
         <img
           src="/svgs/white.svg"
           alt="lvl11-20"
-          style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+          style={{ width: '1em', height: '0.85em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
           onError={(e) => {
             const target = e.target as HTMLImageElement;
             target.outerHTML =
-              '<span style="color: #f8fafc; font-size: ' + Math.max(w, h) + 'px; display: inline;">💎</span>';
+              '<span style="color: #f8fafc; font-size: 1em; display: inline;">💎</span>';
           }}
         />
       );
     }
     // عضو لفل 21-30: ألماسة خضراء
     if (level >= 21 && level <= 30) {
-      const w = size;
-      const h = size * 0.85; // تقصير بالطول فقط
       return (
         <img
           src="/svgs/emerald.svg"
           alt="lvl21-30"
-          style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+          style={{ width: '1em', height: '0.85em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
           onError={(e) => {
             const target = e.target as HTMLImageElement;
             target.outerHTML =
-              '<span style="color: #10b981; font-size: ' + Math.max(w, h) + 'px; display: inline;">💚</span>';
+              '<span style="color: #10b981; font-size: 1em; display: inline;">💚</span>';
           }}
         />
       );
     }
     // عضو لفل 31-40: ألماسة برتقالية مضيئة
     if (level >= 31 && level <= 40) {
-      const w = size;
-      const h = size * 0.85; // تقصير بالطول فقط
       return (
         <img
           src="/svgs/orange_shine.svg"
           alt="lvl31-40"
-          style={{ width: w, height: h, display: 'inline', verticalAlign: 'middle' }}
+          style={{ width: '1em', height: '0.85em', display: 'inline-block', lineHeight: 1, verticalAlign: '-0.15em' }}
           onError={(e) => {
             const target = e.target as HTMLImageElement;
             target.outerHTML =
-              '<span style="color: #f97316; font-size: ' + Math.max(w, h) + 'px; display: inline;">🔥</span>';
+              '<span style="color: #f97316; font-size: 1em; display: inline;">🔥</span>';
           }}
         />
       );
@@ -234,5 +218,12 @@ export default function UserRoleBadge({
   }
   const roleIcon = getUserLevelIcon(user, size);
 
-  return <span className="inline-flex items-center justify-center">{roleIcon}</span>;
+  return (
+    <span
+      className="inline-block"
+      style={{ lineHeight: 1, height: '1em', verticalAlign: '-0.15em' }}
+    >
+      {roleIcon}
+    </span>
+  );
 }


### PR DESCRIPTION
Change UserRoleBadge to use `inline-block` and `em` units to fix inconsistent line spacing in chat messages on mobile Safari.

The `inline-flex` display property combined with pixel-sized icons in the `UserRoleBadge` component caused iOS Safari to incorrectly expand the line box of the first line in chat messages, resulting in an extra gap between the first and second lines when messages wrapped. This change ensures uniform line height.

---
<a href="https://cursor.com/background-agent?bcId=bc-e9340bde-f37a-4d7e-b6dd-3dd5ea397644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e9340bde-f37a-4d7e-b6dd-3dd5ea397644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

