### PR TITLE
Fix chat room message limits and vibrations

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -662,7 +662,7 @@ export default function MessageArea({
             itemContent={(index, message) => (
               <div
                 key={message.id}
-                className={`flex ${isMobile ? 'items-start' : 'items-center'} gap-2 py-1.5 px-2 rounded-lg border-r-4 bg-white shadow-sm hover:shadow-md transition-all duration-300 room-message-pulse soft-entrance`}
+                className={`flex ${isMobile ? 'items-start' : 'items-center'} gap-2 py-1.5 px-2 rounded-lg border-r-4 bg-white shadow-sm hover:shadow-md transition-all duration-300 soft-entrance`}
                 style={{ borderRightColor: getDynamicBorderColor(message.sender) }}
                 data-message-type={message.messageType || 'normal'}
               >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1510,9 +1510,6 @@ li > * > div.effect-crystal {
   animation: subtle-message-float 4s ease-in-out infinite;
 }
 
-.room-message-pulse {
-  animation: gentle-room-pulse 3.5s ease-in-out infinite;
-}
 
 .soft-entrance {
   animation: soft-entrance 0.6s ease-out;

--- a/server/services/roomMessageService.ts
+++ b/server/services/roomMessageService.ts
@@ -124,15 +124,9 @@ class RoomMessageService {
       if (!isSystemMessage) {
         const check = spamProtection.checkMessage(messageData.senderId, messageData.content);
         if (!check.isAllowed) {
-          try {
-            if (check.action === 'tempBan') {
-              await storage.updateUser(messageData.senderId, {
-                isMuted: true as any,
-                muteExpiry: new Date(Date.now() + 60 * 1000) as any,
-              });
-            }
-          } catch {}
-          throw new Error(check.reason || 'تم منع الرسالة بسبب التكرار/السبام');
+          // لا تقُم بكتم المستخدم تلقائياً عند التكرار؛ اكتفِ برسالة خطأ واضحة
+          const reason = check.reason || 'تم منع الرسالة بسبب التكرار. من فضلك غيّر نص الرسالة وحاول مجدداً';
+          throw new Error(reason);
         }
       }
 


### PR DESCRIPTION
Remove message shaking from chat rooms and prevent message sending from stopping due to spam protection by showing an explicit error instead of auto-muting.

The previous spam protection logic would automatically mute users for a short period if they repeated messages, causing messages to stop sending after approximately 17 repetitions without clear feedback, requiring a page refresh. This change provides immediate feedback to the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-0cf70989-290c-42d7-b8c0-db36b7c61a9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0cf70989-290c-42d7-b8c0-db36b7c61a9f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

