### PR TITLE
Fix room display and scrolling issues

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -861,12 +861,13 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     <div
       className={`min-h-[100dvh] flex flex-col chat-container ${isMobile ? 'mobile-layout' : 'desktop-layout'}`}
       onClick={closeUserPopup}
+      style={{ height: '100dvh', overflow: 'hidden' }}
     >
       {/* Modern Header */}
       <header
         className={`fixed top-0 left-0 right-0 z-50 modern-nav app-header safe-area-top h-14 px-2 sm:px-4 flex justify-start items-center ${isMobile ? 'mobile-header' : ''}`}
       >
-        <div className={`flex gap-1 sm:gap-2 overflow-x-auto max-w-full ${isMobile ? 'justify-evenly w-full' : ''}`}>
+        <div className={`flex gap-1 sm:gap-2 overflow-x-hidden max-w-full ${isMobile ? 'justify-evenly w-full' : ''}`}>
           <Button
             className={`glass-effect rounded-lg hover:bg-accent transition-all duration-200 flex items-center ${
               isMobile ? 'flex-1 px-2 py-2 text-xs gap-1.5' : 'px-3 py-2 gap-2'
@@ -1059,7 +1060,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
         style={{ 
           paddingTop: 'var(--app-header-height)', 
           paddingBottom: isMobile ? 'calc(var(--app-footer-height) + env(safe-area-inset-bottom))' : 'var(--app-footer-height)', 
-          height: isMobile ? 'var(--app-body-height)' : undefined 
+          height: 'var(--app-body-height)'
         }}
       >
         {/* الشريط الجانبي - على الجوال يعرض بملء الشاشة عند اختيار التبويب */}
@@ -1223,7 +1224,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
       <footer
         className={`fixed bottom-0 left-0 right-0 z-[60] modern-nav app-footer safe-area-bottom h-14 px-2 sm:px-4 flex justify-start items-center ${isMobile ? 'mobile-footer' : ''}`}
       >
-        <div className={`flex gap-1 sm:gap-2 overflow-x-auto max-w-full ${isMobile ? 'justify-evenly w-full' : ''}`}>
+        <div className={`flex gap-1 sm:gap-2 overflow-x-hidden max-w-full ${isMobile ? 'justify-evenly w-full' : ''}`}>
           {/* الحوائط */}
           <Button
             size="sm"

--- a/client/src/components/chat/FriendsTabPanel.tsx
+++ b/client/src/components/chat/FriendsTabPanel.tsx
@@ -611,20 +611,7 @@ export default function FriendsTabPanel({
         )}
       </div>
 
-      {!isAtBottomFriends && (
-        <div className="absolute bottom-4 right-4 z-10">
-          <Button
-            size="sm"
-            onClick={() => {
-              const el = friendsScrollRef.current;
-              if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-            }}
-            className="px-3 py-1.5 rounded-full text-xs bg-primary text-primary-foreground shadow"
-          >
-            الانتقال لأسفل
-          </Button>
-        </div>
-      )}
+      {false}
     </div>
   );
 }

--- a/client/src/components/chat/RoomComponent.tsx
+++ b/client/src/components/chat/RoomComponent.tsx
@@ -555,14 +555,8 @@ export default function RoomComponent({
       {/* المحتوى */}
       <div
         ref={listScrollRef}
-        onScroll={() => {
-          const el = listScrollRef.current;
-          if (!el) return;
-          const threshold = 80;
-          const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
-          setIsAtBottomRooms(atBottom);
-        }}
         className="relative flex-1 min-h-0 overflow-y-auto cursor-grab bg-background"
+        style={{ maxHeight: 'calc(100dvh - var(--app-header-height) - var(--app-footer-height))' }}
       >
         {/* العنوان - مشابه لقائمة المتصلين */}
         <div className="bg-primary text-primary-foreground mb-1 mx-0 mt-0 rounded-none">
@@ -631,7 +625,7 @@ export default function RoomComponent({
                 </div>
               ) : (
                 <Virtuoso
-                  style={{ height: 'calc(var(--app-body-height) - 204px)' }}
+                  style={{ height: '100%' }}
                   totalCount={filteredRooms.length}
                   itemContent={(index) => {
                     const room = filteredRooms[index];
@@ -665,20 +659,7 @@ export default function RoomComponent({
           style={{ display: 'none' }}
           onChange={handleFileSelected}
         />
-        {!isAtBottomRooms && (
-          <div className="absolute bottom-4 right-4 z-10">
-            <Button
-              size="sm"
-              onClick={() => {
-                const el = listScrollRef.current;
-                if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-              }}
-              className="px-3 py-1.5 rounded-full text-xs bg-primary text-primary-foreground shadow"
-            >
-              الانتقال لأسفل
-            </Button>
-          </div>
-        )}
+        {false}
       </div>
 
       {/* شريط التحكم الصوتي */}

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -286,7 +286,6 @@ export default function UnifiedSidebar({
   const socketRef = useRef<Socket | null>(null);
   const usersScrollRef = useRef<HTMLDivElement>(null);
   const wallsScrollRef = useRef<HTMLDivElement>(null);
-  const [isAtBottomSidebarWall, setIsAtBottomSidebarWall] = useState(true);
   const wallImageInputRef = useRef<HTMLInputElement>(null);
 
   useGrabScroll(usersScrollRef);
@@ -682,17 +681,10 @@ export default function UnifiedSidebar({
               </TabsTrigger>
             </TabsList>
 
-            <div
-              ref={wallsScrollRef}
-              onScroll={() => {
-                const el = wallsScrollRef.current;
-                if (!el) return;
-                const threshold = 80;
-                const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight <= threshold;
-                setIsAtBottomSidebarWall(atBottom);
-              }}
-              className="flex-1 overflow-y-auto px-2 pb-4 cursor-grab"
-            >
+          <div
+            ref={wallsScrollRef}
+            className="flex-1 overflow-y-auto px-2 pb-4 cursor-grab"
+          >
               {/* Post Creation */}
               {currentUser && currentUser.userType !== 'guest' && (
                 <Card className="mb-4 border border-sidebar-border text-sidebar-foreground" style={{ background: 'var(--wall-post-bg)' }}>
@@ -1029,20 +1021,7 @@ export default function UnifiedSidebar({
                 )}
               </TabsContent>
 
-              {!isAtBottomSidebarWall && (
-                <div className="absolute bottom-4 right-4 z-10">
-                  <Button
-                    size="sm"
-                    onClick={() => {
-                      const el = wallsScrollRef.current;
-                      if (el) el.scrollTo({ top: el.scrollHeight, behavior: 'smooth' });
-                    }}
-                    className="px-3 py-1.5 rounded-full text-xs bg-primary text-primary-foreground shadow"
-                  >
-                    الانتقال لأسفل
-                  </Button>
-                </div>
-              )}
+              {false}
             </div>
           </Tabs>
         </div>


### PR DESCRIPTION
Remove redundant scrollbars and "go to bottom" buttons, ensuring only the rooms list scrolls and fills the available height.

This addresses the user's complaint about multiple scrollbars and clipped room content by centralizing scrolling to the rooms area and optimizing layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-010319f6-b6bc-45d0-813f-665308d2afdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-010319f6-b6bc-45d0-813f-665308d2afdc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

