### PR TITLE
Fix connected user count display

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -279,6 +279,37 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
     }
   }, [rooms, updateRoomUserCount]);
 
+  // 🔄 تحديث عدد المستخدمين في الغرف بناءً على قائمة onlineUsers
+  useEffect(() => {
+    if (!chat.onlineUsers || chat.onlineUsers.length === 0) {
+      // إذا لم يكن هناك مستخدمين، تأكد من تحديث جميع الغرف إلى 0
+      rooms.forEach(room => {
+        updateRoomUserCount(room.id, 0);
+      });
+      return;
+    }
+    
+    // حساب عدد المستخدمين لكل غرفة من قائمة onlineUsers
+    const roomUserCounts = new Map<string, number>();
+    
+    chat.onlineUsers.forEach(user => {
+      const userRoom = user.currentRoom || 'general';
+      roomUserCounts.set(userRoom, (roomUserCounts.get(userRoom) || 0) + 1);
+    });
+    
+    // تحديث عدد المستخدمين لكل غرفة
+    roomUserCounts.forEach((count, roomId) => {
+      updateRoomUserCount(roomId, count);
+    });
+    
+    // تحديث الغرف التي ليس فيها مستخدمين إلى 0
+    rooms.forEach(room => {
+      if (!roomUserCounts.has(room.id)) {
+        updateRoomUserCount(room.id, 0);
+      }
+    });
+  }, [chat.onlineUsers, rooms, updateRoomUserCount]);
+
   const [showNotifications, setShowNotifications] = useState(false);
 
   const [showMessages, setShowMessages] = useState(false);

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -164,12 +164,14 @@ export default function UnifiedSidebar({
         return 2;
       case 'moderator':
         return 3;
+      case 'bot':
+        return 4; // البوتات بعد المشرفين
       case 'member':
-        return 4;
-      case 'guest':
         return 5;
-      default:
+      case 'guest':
         return 6;
+      default:
+        return 7;
     }
   };
 


### PR DESCRIPTION
Fixes room user counts showing 0 by dynamically calculating them from online users (including bots) and improves real-time update speed.

The previous implementation for room user counts was not correctly reflecting the actual number of online users in each room, often showing 0. This PR introduces a client-side mechanism to derive these counts from the `onlineUsers` list and ensures server-side updates are more immediate, providing accurate and real-time user counts for all rooms, including bots. It also explicitly orders bots in the user sidebar.

---
<a href="https://cursor.com/background-agent?bcId=bc-565a9827-0b9d-4a28-a324-1546dc5b7549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-565a9827-0b9d-4a28-a324-1546dc5b7549"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

