### PR TITLE
Adjust profile picture dimensions for professional look

### DIFF
--- a/server/services/smartImageService.ts
+++ b/server/services/smartImageService.ts
@@ -215,7 +215,7 @@ class SmartImageService {
     switch (type) {
       case 'avatar':
         sharpInstance = sharpInstance
-          .resize(512, 512, { fit: 'cover', position: 'center' })
+          .resize(400, 400, { fit: 'cover', position: 'center' })
           .webp({ 
             quality: buffer.length > 1024 * 1024 ? 75 : 85,
             effort: 6,


### PR DESCRIPTION
Resize avatar images to 400x400 pixels to align with professional standards used by major websites.

---
<a href="https://cursor.com/background-agent?bcId=bc-353fdc04-d460-4ec2-addc-85d8c48cbb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-353fdc04-d460-4ec2-addc-85d8c48cbb9d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

