### PR TITLE
Enhance chat interface visual elements

### DIFF
--- a/client/src/components/chat/ComposerPlusMenu.tsx
+++ b/client/src/components/chat/ComposerPlusMenu.tsx
@@ -40,14 +40,14 @@ export default function ComposerPlusMenu({ onOpenImagePicker, disabled, isMobile
           variant="outline"
           size={isMobile ? 'icon' : 'icon'}
           disabled={disabled}
-          className={`mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 bg-white text-gray-700 border-gray-300 hover:bg-gray-50`}
+          className={`mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
           title="خيارات"
           aria-label="زر الخيارات"
         >
           <Plus className={`${isMobile ? 'w-6 h-6' : 'w-5 h-5'} shrink-0`} strokeWidth={2.25} />
         </Button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-[12rem]">
+      <DropdownMenuContent align="end" className="min-w-[12rem] bg-popover text-popover-foreground border border-border">
         <DropdownMenuLabel>خيارات إضافية</DropdownMenuLabel>
         {isAuthorized && (
           <DropdownMenuItem onClick={() => onOpenImagePicker && onOpenImagePicker()}>

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -675,7 +675,7 @@ export default function MessageArea({
                                       <span
                                         style={
                                           currentUser && message.senderId === currentUser.id
-                                            ? { color: composerTextColor, fontWeight: composerBold ? 600 : undefined }
+                                            ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
                                             : undefined
                                         }
                                       >
@@ -702,7 +702,7 @@ export default function MessageArea({
                                   className="text-sm leading-relaxed"
                                   style={
                                     currentUser && message.senderId === currentUser.id
-                                      ? { color: composerTextColor, fontWeight: composerBold ? 600 : undefined }
+                                      ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
                                       : undefined
                                   }
                                 >
@@ -914,7 +914,7 @@ export default function MessageArea({
               <Button
                 type="button"
                 variant="outline"
-                size="sm"
+                size={isMobile ? 'icon' : 'icon'}
                 onClick={() => {
                   // إغلاق جميع المنتقات الأخرى
                   setShowEmojiPicker(false);
@@ -925,10 +925,10 @@ export default function MessageArea({
                   setShowEnhancedEmoji(!showEnhancedEmoji);
                 }}
                 disabled={isChatRestricted}
-                className={`aspect-square mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''} ${isChatRestricted ? 'opacity-60 cursor-not-allowed' : ''} bg-primary/10 text-primary border-primary/20 hover:bg-primary/15`}
+                className={`aspect-square mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''} ${isChatRestricted ? 'opacity-60 cursor-not-allowed' : ''} rounded-lg border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
                 title="سمايلات متحركة متقدمة"
               >
-                <Smile className="w-4 h-4" />
+                <Smile className={`${isMobile ? 'w-5 h-5' : 'w-4 h-4'}`} />
               </Button>
               
               {/* Enhanced Emoji Picker (Default) */}
@@ -1000,7 +1000,7 @@ export default function MessageArea({
               placeholder={!currentUser || isChatRestricted ? (getRestrictionMessage || 'هذه الخاصية غير متوفرة الآن') : "اكتب رسالتك هنا..."}
               className={`rooms-message-input flex-1 bg-white text-foreground placeholder:text-muted-foreground rounded-lg border border-gray-300 h-9 focus:border-transparent focus:ring-offset-0 focus-visible:ring-offset-0`}
               disabled={!currentUser || isChatRestricted}
-              style={{ color: composerTextColor, fontWeight: composerBold ? 600 : undefined }}
+              style={{ color: composerTextColor, fontWeight: composerBold ? 700 : undefined }}
               maxLength={MAX_CHARS}
             />
 

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -528,7 +528,7 @@ export default function PrivateMessageBox({
                                     <span
                                       style={
                                         currentUser && m.senderId === currentUser.id
-                                          ? { color: composerTextColor, fontWeight: composerBold ? 600 : undefined }
+                                          ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
                                           : undefined
                                       }
                                     >
@@ -552,7 +552,7 @@ export default function PrivateMessageBox({
                                 className="text-sm leading-relaxed"
                                 style={
                                   currentUser && m.senderId === currentUser.id
-                                    ? { color: composerTextColor, fontWeight: composerBold ? 600 : undefined }
+                                    ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
                                     : undefined
                                 }
                               >
@@ -613,7 +613,7 @@ export default function PrivateMessageBox({
                     placeholder="اكتب رسالتك هنا..."
                     className={`flex-1 bg-gray-50 border text-foreground placeholder:text-muted-foreground rounded-lg border-gray-300`}
                     disabled={false}
-                    style={{ color: composerTextColor, fontWeight: composerBold ? 600 : undefined }}
+                    style={{ color: composerTextColor, fontWeight: composerBold ? 700 : undefined }}
                     maxLength={MAX_CHARS}
                   />
                   {/* زر الإرسال بشكل أيقونة مثل غرف الدردشة */}


### PR DESCRIPTION
Darken bold text and improve styling for the plus and smile buttons.

The bold text for user's own messages is now slightly darker (font-weight 700), and the plus and smile buttons have been restyled to be theme-aware and consistent with other UI elements.

---
<a href="https://cursor.com/background-agent?bcId=bc-efcea69e-e14d-4538-86fb-cca8d19d2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-efcea69e-e14d-4538-86fb-cca8d19d2212"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

