### PR TITLE
Fix chat text color formatting for all users

### DIFF
--- a/TEXT_STYLING_FIX_SUMMARY.md
+++ b/TEXT_STYLING_FIX_SUMMARY.md
@@ -1,0 +1,173 @@
+# إصلاح مشكلة لون الخط والنص الغامق في الرسائل
+
+## المشكلة
+كان المستخدم يستطيع تحديد لون الخط والنص الغامق من قائمة الـ Composer (+)، لكن اللون والتنسيق كانا يظهران فقط للمستخدم نفسه وليس للمستخدمين الآخرين.
+
+## السبب
+- كانت معلومات اللون والخط الغامق تُحفظ فقط في `localStorage` على جهاز المستخدم
+- لم يتم إرسال هذه المعلومات مع الرسالة إلى السيرفر
+- لم يتم حفظها في قاعدة البيانات
+- لم يتم بثها للمستخدمين الآخرين
+
+## الحل المطبق
+
+### 1. تحديث Schema قاعدة البيانات
+**الملف:** `shared/schema.ts`
+
+تم إضافة حقلين جديدين إلى جدول `messages`:
+```typescript
+textColor: text('text_color'), // لون الخط
+bold: boolean('bold').default(false), // الخط الغامق
+```
+
+### 2. تحديث TypeScript Types
+**الملف:** `shared/types.ts`
+
+تم إضافة الحقول إلى `ChatMessage` interface:
+```typescript
+export interface ChatMessage {
+  // ... existing fields
+  textColor?: string;
+  bold?: boolean;
+}
+```
+
+### 3. تحديث الكلاينت
+
+#### أ. تحديث دالة sendMessage
+**الملف:** `client/src/hooks/useChat.ts`
+
+تم تحديث دالة `sendMessage` لقبول معاملات `textColor` و `bold`:
+```typescript
+const sendMessage = useCallback(
+  (content: string, messageType: string = 'text', receiverId?: number, roomId?: string, textColor?: string, bold?: boolean) => {
+    // ... existing code
+    const messageData = {
+      // ... existing fields
+      textColor,
+      bold,
+    };
+  }
+);
+```
+
+#### ب. تحديث MessageArea
+**الملفات المعدلة:**
+- `client/src/components/chat/MessageArea.tsx`
+- `client/src/components/chat/ChatInterface.tsx`
+
+تم تحديث:
+1. `MessageAreaProps` interface لقبول `textColor` و `bold` في `onSendMessage`
+2. دالة `handleSendMessage` لإرسال اللون والخط مع الرسالة
+3. عرض الرسائل لاستخدام `message.textColor` و `message.bold` للجميع (وليس فقط للمستخدم الحالي)
+
+**قبل:**
+```typescript
+style={
+  currentUser && message.senderId === currentUser.id
+    ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
+    : undefined
+}
+```
+
+**بعد:**
+```typescript
+style={{
+  color: message.textColor || '#000000',
+  fontWeight: message.bold ? 700 : undefined
+}}
+```
+
+### 4. تحديث السيرفر
+
+#### أ. تحديث roomMessageService
+**الملف:** `server/services/roomMessageService.ts`
+
+تم تحديث:
+1. signature دالة `sendMessage` لقبول `textColor` و `bold`
+2. تمرير هذه القيم إلى `storage.createMessage`
+
+#### ب. تحديث Socket Handler
+**الملف:** `server/realtime.ts`
+
+تم تحديث معالج `publicMessage` لتمرير `textColor` و `bold`:
+```typescript
+const created = await roomMessageService.sendMessage({
+  // ... existing fields
+  textColor: data?.textColor,
+  bold: data?.bold,
+});
+```
+
+### 5. Migration قاعدة البيانات
+
+تم إنشاء ملفات migration:
+- `migrations/add-message-text-styling.sql` - SQL migration
+- `apply-text-styling-migration.cjs` - Node.js migration script
+
+**لتطبيق الـ Migration:**
+
+```bash
+# إذا كان psql متاحاً
+psql $DATABASE_URL -f migrations/add-message-text-styling.sql
+
+# أو باستخدام Node.js (يتطلب pg module)
+node apply-text-styling-migration.cjs
+```
+
+**SQL Commands:**
+```sql
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS text_color TEXT;
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS bold BOOLEAN DEFAULT false;
+CREATE INDEX IF NOT EXISTS idx_messages_text_styling ON messages(text_color, bold);
+```
+
+## الملفات المعدلة
+
+### Schema & Types
+- ✅ `shared/schema.ts` - إضافة حقول text_color و bold
+- ✅ `shared/types.ts` - تحديث ChatMessage interface
+
+### Client
+- ✅ `client/src/hooks/useChat.ts` - تحديث sendMessage
+- ✅ `client/src/components/chat/MessageArea.tsx` - تحديث العرض والإرسال
+- ✅ `client/src/components/chat/ChatInterface.tsx` - تحديث onSendMessage
+
+### Server
+- ✅ `server/services/roomMessageService.ts` - تحديث sendMessage
+- ✅ `server/realtime.ts` - تحديث publicMessage handler
+
+### Migration
+- ✅ `migrations/add-message-text-styling.sql` - SQL migration
+- ✅ `apply-text-styling-migration.cjs` - Node.js migration script
+
+## التحقق من التطبيق
+
+### قبل تشغيل التطبيق:
+1. تأكد من تطبيق الـ migration على قاعدة البيانات
+2. تأكد من إعادة بناء التطبيق إذا لزم الأمر
+
+### اختبار الإصلاح:
+1. سجل دخول بمستخدمين مختلفين (في متصفحات أو أجهزة مختلفة)
+2. اختر لون خط من قائمة + في أحد المتصفحات
+3. اكتب رسالة وأرسلها
+4. تحقق من ظهور اللون الصحيح في المتصفح الآخر
+5. جرب أيضًا خاصية الخط الغامق
+
+## ملاحظات مهمة
+
+1. **اللون الافتراضي:** إذا لم يتم تحديد لون، سيتم استخدام `#000000` (أسود)
+2. **الخط الغامق:** القيمة الافتراضية هي `false`
+3. **الرسائل القديمة:** الرسائل المُرسلة قبل هذا الإصلاح ستظهر باللون الأسود والخط العادي
+4. **الرسائل الخاصة:** التحديث يشمل الرسائل الخاصة أيضاً
+
+## الخطوات التالية (إذا لزم الأمر)
+
+- [ ] إذابة الـ migration على بيئة الإنتاج
+- [ ] مراقبة الأداء بعد التحديث
+- [ ] إضافة المزيد من خيارات التنسيق (مثل تسطير النص، إلخ) في المستقبل
+
+---
+
+**تاريخ الإصلاح:** 2025-01-01
+**المطور:** Background Agent

--- a/apply-text-styling-migration.cjs
+++ b/apply-text-styling-migration.cjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * Migration Script: Add text styling fields to messages table
+ * This script adds textColor and bold fields to support text styling in messages
+ */
+
+const { Pool } = require('pg');
+
+const DATABASE_URL = process.env.DATABASE_URL || process.env.POSTGRES_URL;
+
+if (!DATABASE_URL) {
+  console.error('❌ Error: DATABASE_URL or POSTGRES_URL environment variable is required');
+  process.exit(1);
+}
+
+const pool = new Pool({
+  connectionString: DATABASE_URL,
+});
+
+async function applyMigration() {
+  console.log('🔄 Starting migration: Add text styling fields to messages...');
+
+  const client = await pool.connect();
+
+  try {
+    // Add textColor column
+    console.log('  ➤ Adding text_color column...');
+    await client.query(`ALTER TABLE messages ADD COLUMN IF NOT EXISTS text_color TEXT`);
+    console.log('  ✅ text_color column added');
+
+    // Add bold column
+    console.log('  ➤ Adding bold column...');
+    await client.query(`ALTER TABLE messages ADD COLUMN IF NOT EXISTS bold BOOLEAN DEFAULT false`);
+    console.log('  ✅ bold column added');
+
+    // Create index for better query performance
+    console.log('  ➤ Creating index for text styling...');
+    await client.query(`CREATE INDEX IF NOT EXISTS idx_messages_text_styling ON messages(text_color, bold)`);
+    console.log('  ✅ Index created');
+
+    console.log('✅ Migration completed successfully!');
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    throw error;
+  } finally {
+    client.release();
+    await pool.end();
+  }
+}
+
+applyMigration()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1146,7 +1146,12 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                       currentUser={chat.currentUser}
                       room={currentRoom}
                       onlineUsers={chat.onlineUsers}
-                      onSendMessage={(content) => chat.sendRoomMessage(content, chat.currentRoomId)}
+                      onSendMessage={(content, messageType, textColor, bold) => {
+                        // Get composer style values
+                        const finalTextColor = textColor || '#000000';
+                        const finalBold = bold || false;
+                        chat.sendMessage(content, messageType || 'text', undefined, chat.currentRoomId, finalTextColor, finalBold);
+                      }}
                       onTyping={(_isTyping) => chat.sendTyping()}
                       typingUsers={Array.from(chat.typingUsers)}
                       onReportMessage={handleReportUser}
@@ -1206,7 +1211,12 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                     <MessageArea
                       messages={chat.publicMessages}
                       currentUser={chat.currentUser}
-                      onSendMessage={(content) => chat.sendRoomMessage(content, chat.currentRoomId)}
+                      onSendMessage={(content, messageType, textColor, bold) => {
+                        // Get composer style values
+                        const finalTextColor = textColor || '#000000';
+                        const finalBold = bold || false;
+                        chat.sendMessage(content, messageType || 'text', undefined, chat.currentRoomId, finalTextColor, finalBold);
+                      }}
                       onTyping={() => chat.sendTyping()}
                       typingUsers={chat.typingUsers}
                       onReportMessage={handleReportUser}

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -40,7 +40,7 @@ import {
 interface MessageAreaProps {
   messages: ChatMessage[];
   currentUser: ChatUser | null;
-  onSendMessage: (content: string, messageType?: string) => void;
+  onSendMessage: (content: string, messageType?: string, textColor?: string, bold?: boolean) => void;
   onTyping: () => void;
   typingUsers: Set<string>;
   onReportMessage?: (user: ChatUser, messageContent: string, messageId: number) => void;
@@ -345,14 +345,14 @@ export default function MessageArea({
         clearTimeout(typingTimeoutRef.current);
       }
 
-      // إرسال الرسالة
-      onSendMessage(trimmedMessage);
+      // إرسال الرسالة مع اللون والخط
+      onSendMessage(trimmedMessage, 'text', composerTextColor, composerBold);
       setMessageText('');
 
       // Focus back to input
       inputRef.current?.focus();
     }
-  }, [messageText, currentUser, onSendMessage]);
+  }, [messageText, currentUser, onSendMessage, composerTextColor, composerBold]);
 
   // Key press handler - إرسال بالـ Enter
   const handleKeyPress = useCallback(
@@ -673,11 +673,10 @@ export default function MessageArea({
                                   <span className="text-sm leading-relaxed inline-flex items-center gap-2">
                                     {cleaned && (
                                       <span
-                                        style={
-                                          currentUser && message.senderId === currentUser.id
-                                            ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
-                                            : undefined
-                                        }
+                                        style={{
+                                          color: message.textColor || '#000000',
+                                          fontWeight: message.bold ? 700 : undefined
+                                        }}
                                       >
                                         {renderMessageWithAnimatedEmojis(
                                           cleaned,
@@ -700,11 +699,10 @@ export default function MessageArea({
                               return (
                                 <span
                                   className="text-sm leading-relaxed"
-                                  style={
-                                    currentUser && message.senderId === currentUser.id
-                                      ? { color: composerTextColor, fontWeight: composerBold ? 700 : undefined }
-                                      : undefined
-                                  }
+                                  style={{
+                                    color: message.textColor || '#000000',
+                                    fontWeight: message.bold ? 700 : undefined
+                                  }}
                                 >
                                   {renderMessageWithAnimatedEmojis(
                                     message.content,

--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1714,7 +1714,7 @@ export const useChat = () => {
 
   // 🔥 SIMPLIFIED Send message function
   const sendMessage = useCallback(
-    (content: string, messageType: string = 'text', receiverId?: number, roomId?: string) => {
+    (content: string, messageType: string = 'text', receiverId?: number, roomId?: string, textColor?: string, bold?: boolean) => {
       if (!state.currentUser || !socket.current?.connected) {
         console.error('❌ لا يمكن إرسال الرسالة - المستخدم غير متصل');
         return;
@@ -1737,6 +1737,8 @@ export const useChat = () => {
         isPrivate: !!receiverId,
         receiverId,
         roomId: roomId || state.currentRoomId,
+        textColor,
+        bold,
       };
 
       if (receiverId) {
@@ -1749,6 +1751,8 @@ export const useChat = () => {
             receiverId,
             content: messageData.content,
             messageType: messageData.messageType || 'text',
+            textColor: messageData.textColor,
+            bold: messageData.bold,
           },
         }).catch(() => {});
       } else {

--- a/migrations/add-message-text-styling.sql
+++ b/migrations/add-message-text-styling.sql
@@ -1,0 +1,12 @@
+-- Migration: Add text styling fields to messages table
+-- Date: 2025-01-01
+-- Description: Add textColor and bold fields to support text styling in messages
+
+-- Add textColor column to messages table
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS text_color TEXT;
+
+-- Add bold column to messages table
+ALTER TABLE messages ADD COLUMN IF NOT EXISTS bold BOOLEAN DEFAULT false;
+
+-- Create index for better query performance (optional)
+CREATE INDEX IF NOT EXISTS idx_messages_text_styling ON messages(text_color, bold);

--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -1265,6 +1265,8 @@ export function setupRealtime(httpServer: HttpServer): IOServer<ClientToServerEv
           content: sanitizedContent,
           messageType: data?.messageType || 'text',
           isPrivate: false,
+          textColor: data?.textColor,
+          bold: data?.bold,
         });
         if (!created) {
           socket.emit('message', { type: 'error', message: 'فشل في إرسال الرسالة' });

--- a/server/services/roomMessageService.ts
+++ b/server/services/roomMessageService.ts
@@ -69,6 +69,8 @@ class RoomMessageService {
     messageType?: string;
     isPrivate?: boolean;
     receiverId?: number;
+    textColor?: string;
+    bold?: boolean;
   }): Promise<RoomMessage | null> {
     try {
       if (!db || dbType === 'disabled') {
@@ -144,6 +146,8 @@ class RoomMessageService {
         isPrivate: messageData.isPrivate || false,
         receiverId: messageData.receiverId || null,
         roomId: messageData.roomId,
+        textColor: messageData.textColor,
+        bold: messageData.bold,
         attachments: (() => {
           try {
             const profileImage: string = (sender as any)?.profileImage || '';

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -75,6 +75,8 @@ export const messages = pgTable(
     isPrivate: boolean('is_private').default(false),
     roomId: text('room_id').default('general'), // معرف الغرفة
     attachments: jsonb('attachments').default([]),
+    textColor: text('text_color'), // لون الخط
+    bold: boolean('bold').default(false), // الخط الغامق
     editedAt: timestamp('edited_at'),
     deletedAt: timestamp('deleted_at'),
     timestamp: timestamp('timestamp').defaultNow(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -65,6 +65,9 @@ export interface ChatMessage {
   myReaction?: 'like' | 'dislike' | 'heart' | null;
   // اختياري: مرفقات الرسالة
   attachments?: any[];
+  // لون الخط والخط الغامق
+  textColor?: string;
+  bold?: boolean;
 }
 
 export interface PrivateConversation {


### PR DESCRIPTION
Enable chat message text color and bold styling to be visible to all users by persisting and broadcasting style information.

Previously, text styling applied by the sender (e.g., text color, bold) was only rendered locally for the sender. This PR extends the message data model and communication flow to include `textColor` and `bold` attributes, ensuring that styling is preserved and displayed correctly for all participants in a chat.

---
<a href="https://cursor.com/background-agent?bcId=bc-74ca4d88-769c-4ade-94bc-38586127bb5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-74ca4d88-769c-4ade-94bc-38586127bb5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

