### PR TITLE
Disable typing indicator in rooms, enable in private chat

### DIFF
--- a/client/src/hooks/useChat.ts
+++ b/client/src/hooks/useChat.ts
@@ -1805,9 +1805,15 @@ export const useChat = () => {
   );
 
   const sendTyping = useCallback(() => {
-    if (socket.current?.connected) {
-      socket.current.emit('typing', { isTyping: true });
-    }
+    // تم تعطيل مؤشر الكتابة في الغرف العامة
+  }, []);
+
+  // إرسال مؤشر كتابة للخاص (DM)
+  const sendPrivateTyping = useCallback((targetUserId: number) => {
+    try {
+      if (!targetUserId || !socket.current?.connected) return;
+      socket.current.emit('privateTyping', { targetUserId, isTyping: true });
+    } catch {}
   }, []);
 
   // Compatibility helpers for UI components
@@ -1923,6 +1929,7 @@ export const useChat = () => {
 
     // Newly added helpers for compatibility
     handleTyping,
+    sendPrivateTyping,
     getCurrentRoomMessages,
     updateCurrentUser,
     loadPrivateConversation,

--- a/server/realtime.ts
+++ b/server/realtime.ts
@@ -1317,19 +1317,26 @@ export function setupRealtime(httpServer: HttpServer): IOServer<ClientToServerEv
       }
     });
 
-    socket.on('typing', (data) => {
-      const isTyping = !!data?.isTyping;
-      const roomId = socket.currentRoom;
-      
-      // المستخدم يجب أن يكون في غرفة لإرسال إشارة الكتابة
-      if (!roomId) return;
-      io.to(`room_${roomId}`).emit('message', {
-        type: 'typing',
-        userId: socket.userId,
-        username: socket.username,
-        isTyping,
-        roomId,
-      });
+    // 🚫 تعطيل مؤشر الكتابة داخل الغرف العامة
+    socket.on('typing', (_data) => {
+      // لم يعد مدعوماً للغرف
+    });
+
+    // ✅ مؤشر الكتابة للرسائل الخاصة فقط
+    socket.on('privateTyping', (data) => {
+      try {
+        if (!socket.userId) return;
+        const targetUserId = Number(data?.targetUserId);
+        const isTyping = !!data?.isTyping;
+        if (!targetUserId || targetUserId === socket.userId) return;
+        // إرسال للمستخدم الهدف فقط
+        io.to(targetUserId.toString()).emit('message', {
+          type: 'privateTyping',
+          fromUserId: socket.userId,
+          fromUsername: socket.username,
+          isTyping,
+        });
+      } catch {}
     });
 
     // Basic WebRTC relays scoped to same room

--- a/server/types/socket.ts
+++ b/server/types/socket.ts
@@ -45,6 +45,7 @@ export interface ClientToServerEvents {
   leaveRoom: (data: any) => void;
   publicMessage: (data: any) => void;
   typing: (data: any) => void;
+  privateTyping: (data: any) => void;
   client_ping: () => void;
   'webrtc-offer': (data: any) => void;
   'webrtc-answer': (data: any) => void;


### PR DESCRIPTION
Disable the typing indicator in public rooms and enable it exclusively for private chats, showing only the other user's typing status.

---
<a href="https://cursor.com/background-agent?bcId=bc-b7877e5a-8ef4-4c8c-beb6-8bb48c949a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b7877e5a-8ef4-4c8c-beb6-8bb48c949a5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

