### PR TITLE
Investigate profile page initial jump animation

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -894,7 +894,7 @@ export default function MessageArea({
 
       {/* Message Input - تحسين التثبيت لمنع التداخل */}
       <div
-        className={`p-2 bg-white w-full z-20 shadow-lg chat-input soft-entrance`}
+        className={`p-2 bg-white w-full z-20 shadow-lg chat-input`}
       >
         {/* Typing Indicator */}
         {typingUsers.size > 0 && (


### PR DESCRIPTION
Remove `soft-entrance` class from the chat input to fix a slight "jump" on first load.

The `soft-entrance` class applied a `transform: translateY(10px)` animation, causing the chat input area to briefly move upwards before settling, which appeared as a "jump" to the user. Removing this class resolves the issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0e68b63-7aa1-40cf-b62e-da70e5443d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0e68b63-7aa1-40cf-b62e-da70e5443d12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

