### PR TITLE
Fix mobile rich tab container shaking

### DIFF
--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -213,7 +213,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
   const topTen = vipUsers.slice(0, 10);
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center">
+    <div className="fixed inset-0 z-50 flex items-center justify-center richest-modal">
       <div className="absolute inset-0 modal-overlay" onClick={onClose} />
 
       <div className="relative w-[90vw] max-w-[24rem] sm:max-w-[26rem] bg-card rounded-xl overflow-hidden shadow-2xl animate-fade-in">
@@ -260,7 +260,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
               <li key={u.id} className="relative -mx-4 list-none">
                 <SimpleUserMenu targetUser={u} currentUser={currentUser || null} showModerationActions={isModerator}>
                   <div
-                    className={`flex items-center gap-2 p-3 px-4 min-h-[56px] rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(u) || 'bg-card hover:bg-accent/10'}`}
+                    className={`mobile-stable flex items-center gap-2 p-3 px-4 min-h-[56px] rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(u) || 'bg-card hover:bg-accent/10'}`}
                     style={getUserListItemStyles(u)}
                     onClick={(e) => onUserClick && onUserClick(e as any, u)}
                   >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1888,6 +1888,31 @@ li > * > div.effect-crystal {
   animation: gradient-x 10s ease infinite;
 }
 
+/* ثبات عناصر الأثرياء على الجوال: إيقاف أي اهتزازات/تحويلات */
+@media (max-width: 768px) {
+  .richest-modal .mobile-stable {
+    /* تعطيل أي تحريك أو اهتزاز يأتي من تأثيرات الخلفية أو الكلاسات المتحركة */
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
+    will-change: auto !important;
+    backface-visibility: hidden;
+    perspective: 0;
+  }
+
+  /* في حال كانت هناك تأثيرات vip-frame أو تأثيرات animate على العناصر الداخلية داخل صف المستخدم */
+  .richest-modal .mobile-stable *,
+  .richest-modal .mobile-stable::before,
+  .richest-modal .mobile-stable::after {
+    animation: none !important;
+  }
+
+  /* منع تأثيرات التحويم من إحداث حركة في الجوال داخل نافذة الأثرياء */
+  .richest-modal .mobile-stable:hover {
+    transform: none !important;
+  }
+}
+
 .richest-close-btn {
   width: 28px;
   height: 28px;


### PR DESCRIPTION
Fix shaking containers in the "Richest" tab on mobile by disabling animations and transforms.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8cf1b51-5959-46de-b01e-2f46c77b63df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b8cf1b51-5959-46de-b01e-2f46c77b63df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

