### PR TITLE
Fix rich tab scrolling for mobile

### DIFF
--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -216,7 +216,10 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
     <div className="fixed inset-0 z-50 flex items-center justify-center richest-modal">
       <div className="absolute inset-0 modal-overlay" onClick={onClose} />
 
-      <div className="relative w-[90vw] max-w-[24rem] sm:max-w-[26rem] bg-card rounded-xl overflow-hidden shadow-2xl animate-fade-in">
+      <div 
+        className="relative w-[90vw] max-w-[24rem] sm:max-w-[26rem] bg-card rounded-xl overflow-hidden shadow-2xl animate-fade-in"
+        style={{ touchAction: 'pan-y pinch-zoom' }}
+      >
         <div className="relative richest-header px-4 py-3 modern-nav flex items-center">
           <button
             onClick={onClose}
@@ -228,7 +231,10 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
           </button>
         </div>
 
-        <div className="max-h-[70vh] overflow-y-auto bg-background">
+        <div 
+          className="max-h-[70vh] overflow-y-auto overflow-x-hidden bg-background"
+          style={{ touchAction: 'pan-y' }}
+        >
           {loading && vipUsers.length === 0 && <ListLoader items={8} itemHeight="h-12" className="p-3" />}
           {error && (
             <div className="text-center text-destructive py-2 text-sm">
@@ -317,7 +323,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
           {canManage && candidates.length > 0 && (
             <div className="border-t border-border p-3">
               <div className="text-sm text-muted-foreground mb-2">مرشحون للإضافة:</div>
-              <div className="space-y-2 max-h-32 overflow-y-auto">
+              <div className="space-y-2 max-h-32 overflow-y-auto overflow-x-hidden">
                 {candidates.map((c) => (
                   <div key={c.id} className="flex items-center gap-2">
                     <img

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1911,6 +1911,37 @@ li > * > div.effect-crystal {
   .richest-modal .mobile-stable:hover {
     transform: none !important;
   }
+
+  /* إصلاح مشكلة الحركة الأفقية في تبويب الأثرياء - السماح فقط بالحركة العمودية */
+  .richest-modal {
+    touch-action: pan-y pinch-zoom !important;
+    overflow-x: hidden !important;
+  }
+  
+  .richest-modal .max-h-\[70vh\] {
+    touch-action: pan-y !important;
+    overflow-x: hidden !important;
+    overscroll-behavior-x: none !important;
+    overscroll-behavior-y: contain !important;
+  }
+
+  /* منع الحركة الأفقية في قائمة المستخدمين */
+  .richest-modal ul {
+    touch-action: pan-y !important;
+    overflow-x: hidden !important;
+  }
+
+  /* منع الحركة الأفقية في عناصر المستخدمين الفردية */
+  .richest-modal li {
+    touch-action: pan-y !important;
+    overflow-x: hidden !important;
+  }
+
+  /* منع الحركة الأفقية في قسم المرشحين */
+  .richest-modal .space-y-2.max-h-32 {
+    touch-action: pan-y !important;
+    overflow-x: hidden !important;
+  }
 }
 
 .richest-close-btn {


### PR DESCRIPTION
Prevent horizontal scrolling in the mobile 'Richest' modal to allow only vertical movement as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-2a631aad-ed40-491b-9e90-df07b7fb6e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2a631aad-ed40-491b-9e90-df07b7fb6e0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

