### PR TITLE
Investigate settings tab opening location

### DIFF
--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -44,7 +44,7 @@ export default function SettingsMenu({
   };
 
   return (
-    <Card className="fixed top-14 left-4 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent relative" role="dialog" aria-modal="true">
+    <Card className="fixed top-16 left-2 z-50 shadow-2xl animate-fade-in w-64 settings-menu-panel border-accent relative sm:w-56" role="dialog" aria-modal="true">
       <CardContent className="p-0">
         {/* زر الإغلاق (X) بنفس تصميم تبويب الأثرياء وفي اليسار) */}
         <button

--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -44,7 +44,7 @@ export default function SettingsMenu({
   };
 
   return (
-    <Card className="fixed top-16 right-2 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent relative sm:top-20 sm:right-4" role="dialog" aria-modal="true">
+    <Card className="fixed top-14 left-4 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent relative" role="dialog" aria-modal="true">
       <CardContent className="p-0">
         {/* زر الإغلاق (X) بنفس تصميم تبويب الأثرياء وفي اليسار) */}
         <button

--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -44,7 +44,7 @@ export default function SettingsMenu({
   };
 
   return (
-    <Card className="fixed top-20 right-4 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent relative" role="dialog" aria-modal="true">
+    <Card className="fixed top-16 right-2 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent relative sm:top-20 sm:right-4" role="dialog" aria-modal="true">
       <CardContent className="p-0">
         {/* زر الإغلاق (X) بنفس تصميم تبويب الأثرياء وفي اليسار) */}
         <button


### PR DESCRIPTION
Adjust `SettingsMenu` positioning to appear correctly on mobile devices.

The settings menu was opening in the middle of the screen on mobile, despite `fixed top-20 right-4` classes. This change adjusts the `top` and `right` values for mobile to `top-16` and `right-2` respectively, while retaining the original `top-20` and `right-4` for larger screens, ensuring the menu appears correctly positioned under the header on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-c54d44e4-b09a-478b-9a1d-fb4f713210f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c54d44e4-b09a-478b-9a1d-fb4f713210f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

