### PR TITLE
Add xp button and fix rooms button in settings

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { lazy, Suspense, useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useLocation } from 'wouter';
+import { saveSession } from '@/lib/socket';
 
 import BlockNotification from '../moderation/BlockNotification';
 import MessageAlert from './MessageAlert';
@@ -1603,6 +1604,7 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
             }}
             onLogout={onLogout}
             onClose={() => setShowSettings(false)}
+            onOpenRooms={() => { try { setShowSettings(false); } catch {}; try { setActiveView('hidden'); } catch {}; try { saveSession({ roomId: 'public' as any }); } catch {}; setLocation('/rooms'); }}
             onOpenReports={() => {
               setShowAdminReports(true);
               setShowSettings(false);

--- a/client/src/components/chat/SettingsMenu.tsx
+++ b/client/src/components/chat/SettingsMenu.tsx
@@ -13,6 +13,7 @@ interface SettingsMenuProps {
   onOpenUsernameColorPicker?: () => void;
   onOpenIgnoredUsers?: () => void;
   onOpenStories?: () => void;
+  onOpenRooms?: () => void;
   currentUser?: any;
 }
 
@@ -25,6 +26,7 @@ export default function SettingsMenu({
   onOpenUsernameColorPicker,
   onOpenIgnoredUsers,
   onOpenStories,
+  onOpenRooms,
   currentUser,
 }: SettingsMenuProps) {
   const handleLogout = () => {
@@ -36,6 +38,17 @@ export default function SettingsMenu({
   return (
     <Card className="fixed top-20 right-4 z-50 shadow-2xl animate-fade-in w-56 settings-menu-panel border-accent">
       <CardContent className="p-0">
+        {/* شريط علوي مع زر إغلاق بنفس تصميم نافذة الأثرياء */}
+        <div className="relative richest-header px-3 py-2 modern-nav border-b border-border">
+          <button
+            onClick={onClose}
+            className="px-2 py-1 hover:bg-red-100 text-red-600 text-sm font-medium absolute left-2 top-1/2 -translate-y-1/2"
+            aria-label="إغلاق"
+            title="إغلاق"
+          >
+            ✖️
+          </button>
+        </div>
         {currentUser && (
           <div className="p-3 border-b border-border" style={getUserListItemStyles(currentUser)}>
             <div className="flex items-center gap-2">
@@ -62,6 +75,7 @@ export default function SettingsMenu({
         {/* القسم الثاني - الإعدادات العامة */}
         <div className="p-3 border-b border-border space-y-1">
           <Button
+            onClick={onOpenRooms}
             variant="ghost"
             size="sm"
             className="w-full justify-start gap-3 h-9 hover:bg-accent/50 text-foreground"


### PR DESCRIPTION
Add a close 'X' button to the settings menu and enable the 'Rooms' button to navigate to the main rooms page.

---
<a href="https://cursor.com/background-agent?bcId=bc-e96691f8-7910-4168-a444-97dbb6ecb695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e96691f8-7910-4168-a444-97dbb6ecb695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

