### PR TITLE
Adjust Toti Bard theme chat colors

### DIFF
--- a/client/src/components/chat/ComposerPlusMenu.tsx
+++ b/client/src/components/chat/ComposerPlusMenu.tsx
@@ -40,7 +40,7 @@ export default function ComposerPlusMenu({ onOpenImagePicker, disabled, isMobile
           variant="outline"
           size={isMobile ? 'icon' : 'icon'}
           disabled={disabled}
-          className={`mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
+          className={`chat-plus-button mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
           title="خيارات"
           aria-label="زر الخيارات"
         >

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1014,7 +1014,7 @@ export default function MessageArea({
                   setShowEnhancedEmoji(!showEnhancedEmoji);
                 }}
                 disabled={isChatRestricted}
-                className={`aspect-square mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''} ${isChatRestricted ? 'opacity-60 cursor-not-allowed' : ''} rounded-lg border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
+                className={`chat-emoji-button aspect-square mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''} ${isChatRestricted ? 'opacity-60 cursor-not-allowed' : ''} rounded-lg border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
                 title="سمايلات متحركة متقدمة"
               >
                 <Smile className={`${isMobile ? 'w-5 h-5' : 'w-4 h-4'}`} />

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -679,7 +679,7 @@ export default function PrivateMessageBox({
                     variant="outline"
                     size="sm"
                     onClick={() => fileInputRef.current?.click()}
-                    className="aspect-square mobile-touch-button min-w-[40px] min-h-[40px] bg-primary/10 text-primary border-primary/20 hover:bg-primary/15"
+                    className="pm-gallery-button aspect-square mobile-touch-button min-w-[40px] min-h-[40px] bg-primary/10 text-primary border-primary/20 hover:bg-primary/15"
                     disabled={false}
                     title="إرسال صورة"
                   >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2285,6 +2285,31 @@ li > * > div.effect-crystal {
   outline-offset: 2px;
 }
 
+/* ===== Theme-specific overrides for Toti Bard (berryCool) ===== */
+[data-theme-id="berryCool"] .chat-emoji-button,
+[data-theme-id="berryCool"] .chat-plus-button {
+  /* Use send button (primary) color instead of dark/neutral */
+  background-color: var(--primary-solid) !important;
+  color: var(--primary-foreground) !important;
+  border-color: color-mix(in srgb, var(--primary-solid) 50%, #000) !important;
+}
+
+[data-theme-id="berryCool"] .chat-emoji-button:hover,
+[data-theme-id="berryCool"] .chat-plus-button:hover {
+  background-color: color-mix(in srgb, var(--primary-solid) 90%, #000) !important;
+}
+
+/* Private messages: make gallery icon white on berryCool */
+[data-theme-id="berryCool"] .pm-gallery-button {
+  background-color: transparent !important; /* keep subtle */
+  color: #ffffff !important; /* icon to white */
+  border-color: rgba(255, 255, 255, 0.18) !important; /* subtle white border */
+}
+
+[data-theme-id="berryCool"] .pm-gallery-button:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
 /* Modern Loading States */
 .loading-shimmer {
   background: linear-gradient(90deg, 

--- a/client/src/utils/applyTheme.ts
+++ b/client/src/utils/applyTheme.ts
@@ -149,6 +149,10 @@ export function applyThemeById(themeId: string, persist: boolean = false) {
 
   const theme = themes[themeId] || themes.default;
   const root = document.documentElement;
+  // Expose current theme id for CSS targeting of theme-specific overrides
+  try {
+    root.setAttribute('data-theme-id', themeId);
+  } catch {}
   const finalCssVars: Record<string, string> = { ...theme.cssVars };
   // Ensure solid variables exist for Tailwind mappings
   if (finalCssVars['--background'] && !finalCssVars['--background-solid']) {


### PR DESCRIPTION
Adjust emoji, plus, and gallery button colors in the Toti Bard theme to match the send button or be white as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-a93b7a58-98f4-4e03-8430-c9c8e344600c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a93b7a58-98f4-4e03-8430-c9c8e344600c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

