### PR TITLE
Display images as icons until clicked

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Dialog, FloatingDialogContent } from '@/components/ui/dialog';
 import ImageLightbox from '@/components/ui/ImageLightbox';
+import ImageAttachmentBadge from '@/components/ui/ImageAttachmentBadge';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { apiRequest, api } from '@/lib/queryClient';
 import type { ChatMessage, ChatUser } from '@/types/chat';
@@ -734,18 +735,15 @@ export default function MessageArea({
                         </div>
                         <div className="runin-text text-gray-800 message-content-fix">
                           {message.messageType === 'image' ? (
-                            <img
-                              src={message.content}
-                              alt="صورة"
-                              className="max-h-40 rounded-lg cursor-pointer shadow-sm hover:shadow-md transition-shadow"
-                              loading="lazy"
-                              onLoad={() => {
-                                if (isAtBottom) {
-                                  scrollToBottom('auto');
-                                }
-                              }}
+                            <button
+                              type="button"
                               onClick={() => setImageLightbox({ open: true, src: message.content })}
-                            />
+                              className="inline-flex items-center justify-center p-0 bg-transparent"
+                              title="عرض الصورة"
+                              aria-label="عرض الصورة"
+                            >
+                              <ImageAttachmentBadge />
+                            </button>
                           ) : (
                             (() => {
                               const { cleaned, ids } = parseYouTubeFromText(message.content);

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, FloatingDialogContent } from '@/components/ui/dialog';
 import ImageLightbox from '@/components/ui/ImageLightbox';
+import ImageAttachmentBadge from '@/components/ui/ImageAttachmentBadge';
 import UserRoleBadge from '@/components/chat/UserRoleBadge';
 import { Input } from '@/components/ui/input';
 // Removed ComposerPlusMenu (ready/quick options)
@@ -586,13 +587,15 @@ export default function PrivateMessageBox({
                             </div>
                           )}
                           {isImage ? (
-                            <img
-                              src={m.content}
-                              alt="صورة"
-                              className="max-h-40 rounded-lg cursor-pointer shadow-sm hover:shadow-md transition-shadow"
-                              loading="lazy"
+                            <button
+                              type="button"
                               onClick={() => setImageLightbox({ open: true, src: m.content })}
-                            />
+                              className="inline-flex items-center justify-center p-0 bg-transparent"
+                              title="عرض الصورة"
+                              aria-label="عرض الصورة"
+                            >
+                              <ImageAttachmentBadge />
+                            </button>
                           ) : (() => {
                             const { cleaned, ids } = parseYouTubeFromText(m.content);
                             if (ids.length > 0) {

--- a/client/src/components/ui/ImageAttachmentBadge.tsx
+++ b/client/src/components/ui/ImageAttachmentBadge.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+
+interface ImageAttachmentBadgeProps {
+  className?: string;
+  title?: string;
+}
+
+// أيقونة تشبه المثال: فقاعة خفيفة وخلفها بطاقة صورة وثلاث نقاط وسهم أخضر
+export default function ImageAttachmentBadge({ className = '', title = 'عرض الصورة' }: ImageAttachmentBadgeProps) {
+  return (
+    <div
+      className={`relative inline-flex items-center justify-center ${className}`}
+      role="img"
+      aria-label={title}
+      title={title}
+      style={{ width: 84, height: 53 }}
+    >
+      <svg width="84" height="53" viewBox="0 0 84 53" aria-hidden="true">
+        {/* فقاعة أساسية */}
+        <g>
+          <path d="M10 11 C10 6, 14 3, 20 3 L56 3 C70 3, 74 10, 74 19 C74 28, 69 33, 58 34 L36 34 L24 46 C23 47, 21 47, 21 45 L22 34 C15 34, 10 29, 10 23 Z" fill="#f1f2f4" />
+        </g>
+        {/* بطاقة صورة داخل الفقاعة */}
+        <g transform="translate(22,12)">
+          <rect x="0" y="0" rx="4" ry="4" width="28" height="20" fill="#fbbf24" />
+          <circle cx="6" cy="5.5" r="3" fill="#ffffff" fillOpacity="0.7" />
+          <path d="M4 16 L11 10 L15 13 L19 11 L24 16 Z" fill="#ffffff" fillOpacity="0.7" />
+        </g>
+        {/* ثلاث نقاط عمودية */}
+        <g transform="translate(54,16)" fill="#c1c6ce">
+          <circle cx="0" cy="2" r="2" />
+          <circle cx="0" cy="9" r="2" />
+          <circle cx="0" cy="16" r="2" />
+        </g>
+        {/* سهم أخضر على اليمين */}
+        <g transform="translate(64,20)">
+          <path d="M0 6 L12 6 M10 2 L12 6 L10 10" stroke="#22c55e" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" fill="none" />
+        </g>
+      </svg>
+    </div>
+  );
+}


### PR DESCRIPTION
Display image attachments in chat messages as a clickable icon to prevent message box clutter.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cc346c3-b33b-4bfb-a6c5-80e599a0311a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9cc346c3-b33b-4bfb-a6c5-80e599a0311a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

