### PR TITLE
Investigate image upload failures

### DIFF
--- a/client/src/components/chat/MediaUploadButton.tsx
+++ b/client/src/components/chat/MediaUploadButton.tsx
@@ -46,11 +46,11 @@ export default function MediaUploadButton({ onMediaSelect, disabled, currentUser
 
     const file = event.target.files?.[0];
     if (file) {
-      if (file.size > 5 * 1024 * 1024) {
-        // 5MB limit
+      if (file.size > 8 * 1024 * 1024) {
+        // 8MB limit
         toast({
           title: 'حجم الملف كبير',
-          description: 'حجم الصورة يجب أن يكون أقل من 5 ميجابايت',
+          description: 'حجم الصورة يجب أن يكون أقل من 8 ميجابايت',
           variant: 'destructive',
         });
         return;

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -514,8 +514,8 @@ export default function MessageArea({
         return;
       }
 
-      if (file.size > 5 * 1024 * 1024) {
-        alert('حجم الصورة كبير جداً. الحد الأقصى 5MB');
+      if (file.size > 8 * 1024 * 1024) {
+        alert('حجم الصورة كبير جداً. الحد الأقصى 8MB');
         if (fileInputRef.current) {
           fileInputRef.current.value = '';
         }


### PR DESCRIPTION
Unify image upload size limits to 8MB across frontend components.

This resolves a conflict where images between 5-8MB were rejected by the frontend due to a 5MB limit, while the backend allowed up to 8MB. Now, both frontend and backend enforce the same 8MB limit, providing a consistent user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-9b5443a9-862a-4980-a9cf-8d28f0e92686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9b5443a9-862a-4980-a9cf-8d28f0e92686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

