### PR TITLE
Troubleshoot image upload failures

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -529,9 +529,18 @@ export default function MessageArea({
         form.append('roomId', currentRoomId || 'general');
         await api.upload('/api/upload/message-image', form, { timeout: 60000 });
         // سيتم بث الرسالة عبر الـ socket من الخادم فلا داعي لاستدعاء onSendMessage محلياً
-      } catch (err) {
+      } catch (err: any) {
         console.error('رفع الصورة فشل:', err);
-        alert('تعذر رفع الصورة، حاول مرة أخرى');
+        const msg = (err && (err.message || err.error)) || '';
+        if (err?.status === 400 && msg) {
+          alert(String(msg));
+        } else if (err?.status === 413) {
+          alert('حجم الملف كبير جداً - يرجى اختيار ملف أصغر');
+        } else if (err?.status === 403) {
+          alert('تعذر تنفيذ العملية (جلسة/صلاحيات). يرجى إعادة المحاولة لاحقاً');
+        } else {
+          alert('تعذر رفع الصورة، حاول مرة أخرى');
+        }
       } finally {
         if (fileInputRef.current) {
           fileInputRef.current.value = '';

--- a/server/services/nsfwService.ts
+++ b/server/services/nsfwService.ts
@@ -59,8 +59,8 @@ class NsfwHeuristicService {
         }
         const ratio = skinLike / (total || 1);
 
-        // إذا تجاوزت نسبة البشرة 60% نعتبرها مخاطرة ونرفض
-        if (ratio >= 0.6) {
+        // إذا تجاوزت نسبة البشرة 80% نعتبرها مخاطرة ونرفض (تخفيف الحساسية لتقليل الإيجابيات الكاذبة)
+        if (ratio >= 0.8) {
           return { isSafe: false, reason: 'تم رفض الصورة لمحتوى محتمل غير لائق' };
         }
       } catch {


### PR DESCRIPTION
Increase NSFW detection threshold to reduce false positives and improve image upload error messages for better user feedback.

The previous NSFW threshold of 0.6 for skin-like pixels was causing legitimate images to be rejected. Raising it to 0.8 aims to mitigate these false positives. Additionally, the client-side error handling for image uploads was too generic, leading to user confusion. This change provides specific error messages for 400 (NSFW), 413 (file size), and 403 (session/permissions) responses, enhancing the user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-afaba5f3-7ad6-4f68-a1db-42c67e92a109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-afaba5f3-7ad6-4f68-a1db-42c67e92a109"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

