### PR TITLE
Fix private message settings and profile display

### DIFF
--- a/client/src/components/chat/ChatInterface.tsx
+++ b/client/src/components/chat/ChatInterface.tsx
@@ -1396,11 +1396,15 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                   if (!updatedUser || !updatedUser.id) return;
                   // لا تحدث حالة المستخدم الحالي إلا إذا كان هو المعني بالتحديث
                   if (chat.currentUser?.id === updatedUser.id) {
-                    chat.updateCurrentUser({
+                    const updates: any = {
                       profileEffect: updatedUser.profileEffect,
                       usernameColor: updatedUser.usernameColor,
                       profileBackgroundColor: updatedUser.profileBackgroundColor,
-                    });
+                    };
+                    if (typeof (updatedUser as any)?.dmPrivacy === 'string') {
+                      updates.dmPrivacy = (updatedUser as any).dmPrivacy;
+                    }
+                    chat.updateCurrentUser(updates);
                   }
                   // تحديث/تنظيف الكاش دائماً للمستخدم الذي تم تحديثه
                   setCachedUser(updatedUser);
@@ -1426,11 +1430,15 @@ export default function ChatInterface({ chat, onLogout }: ChatInterfaceProps) {
                 onUpdate={(updatedUser) => {
                   // تحديث بيانات المستخدم الحالي في قائمة المتصلون
                   if (updatedUser && updatedUser.id) {
-                    chat.updateCurrentUser({
+                    const updates: any = {
                       profileEffect: updatedUser.profileEffect,
                       usernameColor: updatedUser.usernameColor,
                       profileBackgroundColor: updatedUser.profileBackgroundColor,
-                    });
+                    };
+                    if (typeof (updatedUser as any)?.dmPrivacy === 'string') {
+                      updates.dmPrivacy = (updatedUser as any).dmPrivacy;
+                    }
+                    chat.updateCurrentUser(updates);
                     // تحديث/تنظيف الكاش بعد التحديث الناجح
                     setCachedUser(updatedUser);
                     // إيقاف الصوت الخارجي إذا تمت إزالة موسيقى البروفايل

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -3397,6 +3397,7 @@ export default function ProfileModal({
                         padding: '4px 8px',
                         fontSize: '12px'
                       }}
+                      value={(localUser as any)?.dmPrivacy || 'all'}
                       onChange={(e) => updateDmPrivacy(e.target.value as 'all' | 'friends' | 'none')}
                     >
                       <option value="all">السماح للجميع</option>


### PR DESCRIPTION
Update `ProfileModal` to display current DM privacy and `ChatInterface` to update `dmPrivacy` state immediately.

This fixes the issue where private message settings in the profile modal and chat interface did not update visually without a page refresh, ensuring the UI reflects the current setting.

---
<a href="https://cursor.com/background-agent?bcId=bc-f4d9ba90-94e8-430d-b741-90cd1ba99e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f4d9ba90-94e8-430d-b741-90cd1ba99e13"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

