### PR TITLE
Check system readiness

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2727,3 +2727,20 @@ li::before {
     line-height: 1.3 !important;
   }
 }
+
+/* ===== arabic.chat-like public room name:message layout (literal) ===== */
+.ch_logs .my_text .cname {
+  display: grid;
+  grid-template-columns: max-content 1fr auto;
+  column-gap: 0.5rem;
+  align-items: start;
+}
+.ch_logs .my_text .cname > .rtl_fright {
+  float: none !important;
+  white-space: nowrap;
+  text-align: end;
+}
+.ch_logs .my_text .cname > .chat_message {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}


### PR DESCRIPTION
Add CSS rules to display chat usernames next to messages with wrapped lines aligning under the message text in public rooms.

These styles implement the user's requested chat message display for public rooms, mimicking the layout where the sender's name is adjacent to the message and subsequent lines wrap beneath the message content.

---
<a href="https://cursor.com/background-agent?bcId=bc-4bd471c3-67fe-465b-af80-64eec697f15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4bd471c3-67fe-465b-af80-64eec697f15f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

