### PR TITLE
Customize admin profile and chat name colors

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -27,7 +27,7 @@ import {
   insertMention,
 } from '@/utils/mentionUtils';
 import { getDynamicBorderColor } from '@/utils/messageUtils';
-import { getFinalUsernameColor } from '@/utils/themeUtils';
+import { getFinalUsernameColor, getUserNameplateStyles } from '@/utils/themeUtils';
 import { formatTime } from '@/utils/timeUtils';
 // Removed ComposerPlusMenu (ready/quick options)
 import { useComposerStyle } from '@/contexts/ComposerStyleContext';
@@ -691,13 +691,33 @@ export default function MessageArea({
                               <UserRoleBadge user={message.sender} size={14} hideGuestAndGender />
                             </span>
                           )}
-                          <button
-                            onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
-                            className="font-semibold hover:underline transition-colors duration-200 text-sm"
-                            style={{ color: getFinalUsernameColor(message.sender) }}
-                          >
-                            {message.sender?.username || 'جاري التحميل...'}
-                          </button>
+                          {(() => {
+                            const np = getUserNameplateStyles(message.sender);
+                            const hasNp = np && Object.keys(np).length > 0;
+                            if (hasNp) {
+                              return (
+                                <button
+                                  onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                                  className="transition-transform duration-200 hover:scale-[1.02]"
+                                  title={message.sender?.username}
+                                >
+                                  <span className="ac-nameplate" style={np}>
+                                    <span className="ac-name">{message.sender?.username || '...'}</span>
+                                    <span className="ac-mark">〰</span>
+                                  </span>
+                                </button>
+                              );
+                            }
+                            return (
+                              <button
+                                onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                                className="font-semibold hover:underline transition-colors duration-200 text-sm"
+                                style={{ color: getFinalUsernameColor(message.sender) }}
+                              >
+                                {message.sender?.username || 'جاري التحميل...'}
+                              </button>
+                            );
+                          })()}
                           <span className="text-red-400 mx-1">:</span>
                         </div>
 
@@ -747,13 +767,33 @@ export default function MessageArea({
                             <UserRoleBadge user={message.sender} size={14} hideGuestAndGender />
                           </span>
                         )}
-                          <button
-                            onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
-                            className="font-semibold hover:underline transition-colors duration-200 text-sm"
-                            style={{ color: getFinalUsernameColor(message.sender) }}
-                          >
-                            {message.sender?.username || 'جاري التحميل...'}
-                          </button>
+                          {(() => {
+                            const np = getUserNameplateStyles(message.sender);
+                            const hasNp = np && Object.keys(np).length > 0;
+                            if (hasNp) {
+                              return (
+                                <button
+                                  onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                                  className="transition-transform duration-200 hover:scale-[1.02]"
+                                  title={message.sender?.username}
+                                >
+                                  <span className="ac-nameplate" style={np}>
+                                    <span className="ac-name">{message.sender?.username || '...'}</span>
+                                    <span className="ac-mark">〰</span>
+                                  </span>
+                                </button>
+                              );
+                            }
+                            return (
+                              <button
+                                onClick={(e) => message.sender && handleUsernameClick(e, message.sender)}
+                                className="font-semibold hover:underline transition-colors duration-200 text-sm"
+                                style={{ color: getFinalUsernameColor(message.sender) }}
+                              >
+                                {message.sender?.username || 'جاري التحميل...'}
+                              </button>
+                            );
+                          })()}
                           <span className="text-gray-400 mx-1">:</span>
                         </div>
                         <div className="runin-text text-gray-900 message-content-fix">

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -20,7 +20,7 @@ import {
   formatMessagePreview,
   setPmLastOpened,
 } from '@/utils/messageUtils';
-import { getFinalUsernameColor } from '@/utils/themeUtils';
+import { getFinalUsernameColor, getUserNameplateStyles } from '@/utils/themeUtils';
 import { getSocket } from '@/lib/socket';
 import { formatTime } from '@/utils/timeUtils';
 // إزالة استخدام fallback الذي يُظهر "مستخدم #id" لتفادي ظهور اسم افتراضي خاطئ في الخاص
@@ -425,30 +425,58 @@ export default function PrivateMessageBox({
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-2">
                   <div className="flex items-center gap-2 min-w-0">
-                    <span
-                      className="text-base font-medium transition-all duration-300 truncate cursor-pointer hover:underline"
-                      onClick={handleViewProfileClick}
-                      role="button"
-                      tabIndex={0}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault();
-                          handleViewProfileClick();
-                        }
-                      }}
-                      style={{
-                        color: getFinalUsernameColor(user),
-                        textShadow: getFinalUsernameColor(user)
-                          ? `0 0 10px ${getFinalUsernameColor(user)}40`
-                          : 'none',
-                        filter: getFinalUsernameColor(user)
-                          ? 'drop-shadow(0 0 3px rgba(255,255,255,0.3))'
-                          : 'none',
-                      }}
-                      title={user.username}
-                    >
-                      {user.username || 'جاري التحميل...'}
-                    </span>
+                    {(() => {
+                      const np = getUserNameplateStyles(user);
+                      const hasNp = np && Object.keys(np).length > 0;
+                      if (hasNp) {
+                        return (
+                          <button
+                            onClick={handleViewProfileClick}
+                            role="button"
+                            tabIndex={0}
+                            className="truncate transition-transform duration-200 hover:scale-[1.02]"
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
+                                handleViewProfileClick();
+                              }
+                            }}
+                            title={user.username}
+                          >
+                            <span className="ac-nameplate" style={np}>
+                              <span className="ac-name">{user.username || '...'}</span>
+                              <span className="ac-mark">〰</span>
+                            </span>
+                          </button>
+                        );
+                      }
+                      return (
+                        <span
+                          className="text-base font-medium transition-all duration-300 truncate cursor-pointer hover:underline"
+                          onClick={handleViewProfileClick}
+                          role="button"
+                          tabIndex={0}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              handleViewProfileClick();
+                            }
+                          }}
+                          style={{
+                            color: getFinalUsernameColor(user),
+                            textShadow: getFinalUsernameColor(user)
+                              ? `0 0 10px ${getFinalUsernameColor(user)}40`
+                              : 'none',
+                            filter: getFinalUsernameColor(user)
+                              ? 'drop-shadow(0 0 3px rgba(255,255,255,0.3))'
+                              : 'none',
+                          }}
+                          title={user.username}
+                        >
+                          {user.username || 'جاري التحميل...'}
+                        </span>
+                      );
+                    })()}
                     <UserRoleBadge user={user} size={20} />
                   </div>
                   {/* زر الإغلاق يسار بنفس نمط الأثرياء/الإعدادات */}
@@ -530,12 +558,30 @@ export default function PrivateMessageBox({
                         {/* run-in on mobile; horizontal on desktop */}
                         <div className="runin-container">
                           <div className="runin-name">
-                            <span
-                              className="font-semibold text-sm"
-                              style={{ color: getFinalUsernameColor(m.sender || user) }}
-                            >
-                              {m.sender?.username || (isMe ? (currentUser?.username || '') : (user.username || '')) || 'جاري التحميل...'}
-                            </span>
+                            {(() => {
+                              const senderUser = (m.sender as ChatUser) || (isMe ? currentUser : user);
+                              const np = getUserNameplateStyles(senderUser);
+                              const hasNp = np && Object.keys(np).length > 0;
+                              const displayName = senderUser?.username || '...';
+                              if (hasNp) {
+                                return (
+                                  <span className="font-semibold text-sm">
+                                    <span className="ac-nameplate" style={np}>
+                                      <span className="ac-name">{displayName}</span>
+                                      <span className="ac-mark">〰</span>
+                                    </span>
+                                  </span>
+                                );
+                              }
+                              return (
+                                <span
+                                  className="font-semibold text-sm"
+                                  style={{ color: getFinalUsernameColor(senderUser) }}
+                                >
+                                  {displayName}
+                                </span>
+                              );
+                            })()}
                             <span className="text-gray-400 mx-1">:</span>
                           </div>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -527,6 +527,44 @@ img, video, canvas, iframe {
   color: hsl(197, 100%, 75%);
 }
 
+/* ===== Gradient Nameplate (matches profile background exactly) ===== */
+.ac-nameplate {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 9999px;
+  line-height: 1;
+  font-weight: 700;
+  font-size: 13px;
+  color: #fff;
+  background: var(--nameplate-bg, transparent); /* actual gradient comes from style attr */
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.25), inset 0 1px 0 rgba(255,255,255,0.18);
+  -webkit-backdrop-filter: blur(6px);
+  backdrop-filter: blur(6px);
+}
+
+.ac-nameplate .ac-name {
+  color: #fff;
+  text-shadow: 0 1px 2px rgba(0,0,0,0.25);
+}
+
+.ac-nameplate .ac-mark {
+  font-size: 12px;
+  opacity: 0.95;
+}
+
+.ac-nameplate .ac-left {
+  font-size: 12px;
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.25));
+}
+
+.ac-nameplate .ac-right {
+  font-size: 12px;
+  filter: drop-shadow(0 1px 1px rgba(0,0,0,0.25));
+}
+
 .chat-message {
   padding: 16px 20px;
   margin: 12px 0;

--- a/client/src/utils/themeUtils.ts
+++ b/client/src/utils/themeUtils.ts
@@ -255,6 +255,32 @@ export const getUserListItemClasses = (user: any): string => {
   return classes.join(' ');
 };
 
+// ===== Nameplate (username badge) helpers =====
+// Build inline styles for a gradient nameplate that exactly matches the
+// user's profile background color. Applied only for privileged roles
+// that have custom backgrounds (admin/moderator/owner) as requested.
+export const getUserNameplateStyles = (user: any): Record<string, string> => {
+  if (!user) return {};
+  const role: string = String(user.userType || '').toLowerCase();
+  const isPrivileged = role === 'admin' || role === 'moderator' || role === 'owner';
+  const hasBg = !!(user.profileBackgroundColor && user.profileBackgroundColor !== 'null' && user.profileBackgroundColor !== 'undefined');
+  if (!isPrivileged || !hasBg) return {};
+
+  const bg = buildProfileBackgroundGradient(String(user.profileBackgroundColor));
+  if (!bg || !bg.startsWith('linear-gradient(')) return {};
+
+  // Ensure perfect visual match with the user list/profile card
+  const styles: Record<string, string> = {
+    backgroundImage: bg,
+    backgroundBlendMode: 'normal',
+    color: '#ffffff',
+    border: '1px solid rgba(255,255,255,0.28)',
+    boxShadow: '0 1px 4px rgba(0,0,0,0.25), inset 0 1px 0 rgba(255,255,255,0.18)',
+    // Geometry and spacing kept in CSS class `.ac-nameplate`
+  };
+  return styles;
+};
+
 // دالة للحصول على البيانات الكاملة للتأثير للمستخدم
 export const getUserThemeAndEffect = (user: any) => {
   return {


### PR DESCRIPTION
Implement gradient nameplates for privileged users in chat messages to visually match their profile background colors.

---
<a href="https://cursor.com/background-agent?bcId=bc-0c157e18-8371-4ead-ac84-4f7a67d98518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0c157e18-8371-4ead-ac84-4f7a67d98518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

