### PR TITLE
Build project and upload artifacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "dev": "NODE_ENV=development tsx server/index.ts",
-    "build": "npx vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && ( [ -d migrations ] && cp -r migrations dist/ || true ) && cp -r shared dist/ && cp deploy-fix.js . || true && npm run postbuild",
+    "build": "npx vite build && npx esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist && ( [ -d migrations ] && cp -r migrations dist/ || true ) && cp -r shared dist/ && cp deploy-fix.js . || true && npm run postbuild",
     "deploy-fix": "NODE_ENV=production node deploy-fix.js",
     "start": "NODE_ENV=production node dist/index.js",
     "postbuild": "echo '✅ البناء مكتمل'",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,13 +11,13 @@ export default defineConfig({
 	],
 	resolve: {
 		alias: {
-			'@': path.resolve(import.meta.dirname, 'src'),
+			'@': path.resolve(import.meta.dirname, 'client/src'),
 			'@shared': path.resolve(import.meta.dirname, 'shared'),
 			'@assets': path.resolve(import.meta.dirname, 'attached_assets'),
 		},
 	},
-	root: import.meta.dirname,
-	publicDir: path.resolve(import.meta.dirname, 'public'),
+	root: path.resolve(import.meta.dirname, 'client'),
+	publicDir: path.resolve(import.meta.dirname, 'client/public'),
 	build: {
 		outDir: path.resolve(import.meta.dirname, 'dist/public'),
 		emptyOutDir: true,


### PR DESCRIPTION
Fix Vite build configuration and `esbuild` command to resolve frontend and backend build failures.

The Vite build failed to find `index.html` because its `root` and `publicDir` were incorrectly set to the project root instead of the `client/` directory. Additionally, the server build failed because `esbuild` was not globally available and needed to be invoked via `npx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d8bce17-fda4-4b75-b43b-8fde4d0e32a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d8bce17-fda4-4b75-b43b-8fde4d0e32a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

