### PR TITLE
Fix emoji display in chat input

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -443,8 +443,9 @@ export default function MessageArea({
 
   // Animated Emoji select handler
   const handleAnimatedEmojiSelect = useCallback((emoji: { id: string; url: string; name: string; code: string }) => {
-    // إدراج كود السمايل في الرسالة
-    const newText = clampToMaxChars(messageText + ` [[emoji:${emoji.id}:${emoji.url}]] `);
+    // أدخل كود السمايل المختصر بدل الرابط لتجنب ظهور رابط داخل خانة الدردشة
+    const token = (emoji.code && emoji.code.trim()) || `[[emoji:${emoji.id}:${emoji.url}]]`;
+    const newText = clampToMaxChars(messageText + ` ${token} `);
     setMessageText(newText);
     setShowAnimatedEmojiPicker(false);
     inputRef.current?.focus();
@@ -454,11 +455,11 @@ export default function MessageArea({
   const handleEmojiMartSelect = useCallback((emoji: any) => {
     let newText;
     if (emoji.src) {
-      // إيموجي مخصص (GIF)
+      // إيموجي مخصص (GIF) من emoji-mart: نُبقيه بصيغة الرمز حتى العرض
       newText = clampToMaxChars(messageText + ` [[emoji:${emoji.id}:${emoji.src}]] `);
     } else {
-      // إيموجي عادي
-      newText = clampToMaxChars(messageText + emoji.native);
+      // إيموجي عادي (نظامي)
+      newText = clampToMaxChars(messageText + (emoji.native || ''));
     }
     setMessageText(newText);
     setShowEmojiMart(false);
@@ -475,14 +476,15 @@ export default function MessageArea({
 
   // Enhanced Emoji handler
   const handleEnhancedEmojiSelect = useCallback((emoji: { id: string; emoji?: string; name: string; code: string; url?: string }) => {
-    let newText: string;
+    let token: string;
     if (emoji.url) {
-      // إيموجي مخصص بصورة متحركة
-      newText = clampToMaxChars(messageText + ` [[emoji:${emoji.id}:${emoji.url}]] `);
+      // استخدم الكود المختصر بدلاً من الرابط لتفادي ظهور رابط داخل خانة الدردشة
+      token = (emoji.code && emoji.code.trim()) || `[[emoji:${emoji.id}:${emoji.url}]]`;
     } else {
       // إيموجي عادي
-      newText = clampToMaxChars(messageText + (emoji.emoji || emoji.code));
+      token = emoji.emoji || emoji.code;
     }
+    const newText = clampToMaxChars(messageText + ` ${token} `);
     setMessageText(newText);
     setShowEnhancedEmoji(false);
     inputRef.current?.focus();

--- a/package-lock.json
+++ b/package-lock.json
@@ -143,7 +143,7 @@
         "tailwindcss": "^3.4.17",
         "terser": "^5.43.1",
         "tsx": "^4.20.6",
-        "typescript": "^5.9.2",
+        "typescript": "^5.9.3",
         "typescript-eslint": "^8.39.0",
         "vite": "^6.3.5"
       },
@@ -14250,9 +14250,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -169,7 +169,7 @@
     "tailwindcss": "^3.4.17",
     "terser": "^5.43.1",
     "tsx": "^4.20.6",
-    "typescript": "^5.9.2",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.39.0",
     "vite": "^6.3.5"
   },


### PR DESCRIPTION
Insert emojis as glyphs or shortcodes in chat input to prevent them from appearing as URLs.

Previously, animated and custom emojis were inserted as full URL tokens (`[[emoji:id:url]]`), causing them to display as links in the chat input field. This change modifies the emoji selection handlers (`handleAnimatedEmojiSelect`, `handleEnhancedEmojiSelect`) to prioritize inserting the emoji's native glyph or its shortcode (`emoji.code`) when available, falling back to the URL token only if no other representation exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1e77f2c-6d74-4f57-9521-61822fccb7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1e77f2c-6d74-4f57-9521-61822fccb7ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

