### PR TITLE
Straighten profile picture corners

### DIFF
--- a/client/src/components/chat/ProfileImage.tsx
+++ b/client/src/components/chat/ProfileImage.tsx
@@ -59,7 +59,7 @@ export default function ProfileImage({
       <img
         src={imageSrc}
         alt={`صورة ${user.username}`}
-        className={`${sizeClasses[size]} rounded-full ring-2 ${borderColor} shadow-sm object-cover ${className}`}
+        className={`${sizeClasses[size]} ring-2 ${borderColor} shadow-sm object-cover ${className}`}
         style={{
           transition: 'none',
           backfaceVisibility: 'hidden',

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2247,7 +2247,7 @@ export default function ProfileModal({
         .profile-avatar {
           width: 130px;
           height: 130px;
-          border-radius: 16px;
+          border-radius: 0;
           overflow: hidden;
           position: absolute;
           top: calc(100% - 130px);

--- a/client/src/components/ui/avatar.tsx
+++ b/client/src/components/ui/avatar.tsx
@@ -11,7 +11,7 @@ const Avatar = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <AvatarPrimitive.Root
     ref={ref}
-    className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden rounded-full', className)}
+    className={cn('relative flex h-10 w-10 shrink-0 overflow-hidden', className)}
     {...props}
   />
 ));
@@ -36,7 +36,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      'flex h-full w-full items-center justify-center rounded-full bg-muted',
+      'flex h-full w-full items-center justify-center bg-muted',
       className
     )}
     {...props}


### PR DESCRIPTION
Make profile picture corners straight by removing `border-radius` from relevant avatar and profile image components.

---
<a href="https://cursor.com/background-agent?bcId=bc-570918d6-c328-4571-a61d-3efc70cfc53c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-570918d6-c328-4571-a61d-3efc70cfc53c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

