### PR TITLE
Straighten profile card corners

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2197,7 +2197,7 @@ export default function ProfileModal({
         .profile-card {
           width: 100%;
           max-width: 520px;
-          border-radius: 16px;
+          border-radius: 0;
           overflow: hidden;
           background: var(--card-bg);
           box-shadow: 0 8px 32px rgba(0,0,0,0.8);


### PR DESCRIPTION
Make the profile card corners straight by setting `border-radius` to 0.

The user explicitly requested to remove the rounded corners from the profile card, making all four corners straight instead of curved.

---
<a href="https://cursor.com/background-agent?bcId=bc-aa4a8bb4-8ea2-4e7c-8725-9f12d6cd3a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa4a8bb4-8ea2-4e7c-8725-9f12d6cd3a67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

