### PR TITLE
Do essential work

### DIFF
--- a/client/src/lib/connectionManager.ts
+++ b/client/src/lib/connectionManager.ts
@@ -70,10 +70,11 @@ export class ConnectionManager {
     });
 
     window.addEventListener('error', (event: ErrorEvent) => {
-      if (!this.cfg.errorReportUrl) return;
+      const url = this.cfg.errorReportUrl || '/collect/e.php';
+      if (!url) return;
       try {
         const message = `${event?.error?.message || event?.message || 'Unknown error'}\n${event?.error?.stack || ''}`;
-        fetch(this.cfg.errorReportUrl, {
+        fetch(url, {
           method: 'POST',
           headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
           body: new URLSearchParams({ e: message }).toString(),

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4596,6 +4596,27 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // ===== Error collection endpoint to mimic competitor's auto-reload behavior =====
+  // Receives window error reports and responds with '1' so client can hard-reload
+  app.post('/collect/e.php', async (req, res) => {
+    try {
+      const raw = (req as any)?.body || {};
+      const message: string = String((raw?.e ?? raw?.error ?? raw?.message ?? ''));
+      const logLine = `[${new Date().toISOString()}] ${message.slice(0, 2000)}\n`;
+      try {
+        const logDir = path.join(process.cwd(), 'logs');
+        await fsp.mkdir(logDir, { recursive: true }).catch(() => {});
+        await fsp.appendFile(path.join(logDir, 'client-errors.log'), logLine).catch(() => {});
+      } catch {}
+    } catch {}
+    try {
+      res.setHeader('Cache-Control', 'no-store');
+      res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    } catch {}
+    // Always return '1' to instruct the client to reload (matches competitor behavior)
+    res.status(200).send('1');
+  });
+
   // تعيين مستوى المستخدم مباشرة (للمالك فقط)
   app.post('/api/points/set-level', async (req, res) => {
     try {


### PR DESCRIPTION
Implement client-side error reporting with automatic page reload to mimic competitor's robust session recovery and background operation.

This PR introduces an endpoint `/collect/e.php` and modifies the client to send JavaScript errors to it. The client will automatically reload if the server responds with '1', replicating a key resilience mechanism from the reference site to ensure the application recovers from unexpected client-side errors and maintains a fresh session.

---
<a href="https://cursor.com/background-agent?bcId=bc-5e267511-62f8-486a-aefa-191f75b741be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5e267511-62f8-486a-aefa-191f75b741be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

