### PR TITLE
Simplify mobile chat room message display

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -650,7 +650,7 @@ export default function MessageArea({
   }, []);
 
   return (
-    <section className={`flex-1 flex flex-col bg-white min-h-0 ${isMobile ? 'mobile-message-area' : ''}`}>
+    <section className="flex-1 flex flex-col bg-white min-h-0">
       {/* Chat Lock Status Indicator */}
       {(chatLockAll || chatLockVisitors) && (
         <div className={`px-4 py-2 text-center text-sm font-medium border-b ${
@@ -717,7 +717,7 @@ export default function MessageArea({
                       </div>
                     )}
                     <div className="flex-1 min-w-0">
-                      <div className={`flex items-start gap-2 ${isMobile ? 'system-message-mobile' : ''}`}>
+                      <div className="flex items-start gap-2">
                         {/* Name and badge section - fixed width */}
                         <div className="flex items-center gap-1 shrink-0">
                           {message.sender && (
@@ -756,7 +756,7 @@ export default function MessageArea({
                         </div>
 
                         {/* Content section - flexible width (one-line, full content) */}
-                        <div className={`flex-1 min-w-0 text-red-600 message-content-fix ${isMobile ? 'system-message-content' : ''} whitespace-nowrap`}>
+                        <div className="flex-1 min-w-0 text-red-600 message-content-fix whitespace-nowrap">
                           <span>{message.content}</span>
                         </div>
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1670,19 +1670,17 @@ li > * > div.effect-crystal {
 
 /* Mobile message rows: keep same structure, remove colored right strip only */
 @media (max-width: 768px) {
-  .mobile-message-area .ac-message-row {
-    border-right: 0 !important; /* remove colored strip */
+  /* Unified renderer: no special mobile container needed */
+  .ac-message-row {
+    border-right: 0 !important; /* remove colored strip on small screens for readability */
     border-radius: inherit !important;
   }
-  .mobile-message-area .ac-message-row .runin-name button {
+  .ac-message-row .runin-name button {
     font-weight: 700;
   }
-  /* keep colon and text colors consistent with desktop classes */
-  /* hide inline timestamp on mobile (unchanged) */
-  .mobile-message-area .ac-time {
+  .ac-time {
     display: none !important;
   }
-  /* composer styling unchanged */
   .ac-composer {
     border: 1px solid #e5e7eb;
     border-radius: 10px;
@@ -2701,10 +2699,10 @@ li::before {
   }
 
   /* منع تكبير iOS عند التركيز على حقول الإدخال */
-  .mobile-message-area input[type="text"],
-  .mobile-message-area input[type="search"],
-  .mobile-message-area input[type="email"],
-  .mobile-message-area input[type="password"],
+  input[type="text"],
+  input[type="search"],
+  input[type="email"],
+  input[type="password"],
   .rooms-message-input {
     font-size: 16px !important;
   }
@@ -2722,37 +2720,18 @@ li::before {
   }
 
   /* تحسين رسائل النظام للجوال */
-  .system-message-mobile {
-    align-items: center !important;
-    gap: 8px !important;
-  }
-
-  .system-message-content {
-    font-size: 14px;
-    line-height: 1.3;
-    margin: 0;
-    padding: 0;
-    word-break: break-word;
-    overflow-wrap: break-word;
-  }
-
-  /* تحسين عرض رسائل النظام على الجوال - إزالة الفراغات الزائدة */
-  .mobile-message-area [data-message-type="system"] {
+  /* Unified system message styles on small screens */
+  [data-message-type="system"] {
     padding: 8px 12px !important;
     margin: 4px 8px !important;
     min-height: auto;
     align-items: center !important;
   }
-
-  /* ضبط التخطيط ليكون مماثل لسطح المكتب */
-  .mobile-message-area [data-message-type="system"] .system-message-mobile {
-    align-items: center !important;
-    gap: 8px !important;
-  }
-
-  .mobile-message-area [data-message-type="system"] .system-message-content {
+  .system-message-content, [data-message-type="system"] .message-content-fix {
     font-size: 14px !important;
     line-height: 1.3 !important;
+    word-break: break-word;
+    overflow-wrap: break-word;
   }
 }
 


### PR DESCRIPTION
Unify message rendering in chat rooms for mobile and desktop to provide a consistent user experience.

The previous mobile message display had separate logic and styling, which the user found complex. This change removes mobile-specific classes and conditional rendering in `MessageArea.tsx`, instead using media queries in `index.css` to adapt the unified desktop rendering for smaller screens, simplifying the codebase and ensuring a consistent look.

---
<a href="https://cursor.com/background-agent?bcId=bc-bd32b375-5d0e-44b5-9a2c-f7fb477f9421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bd32b375-5d0e-44b5-9a2c-f7fb477f9421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

