### PR TITLE
Update tab styling for toti bard theme

### DIFF
--- a/client/src/components/moderation/ActiveModerationLog.tsx
+++ b/client/src/components/moderation/ActiveModerationLog.tsx
@@ -154,8 +154,16 @@ export default function ActiveModerationLog({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-4xl h-[80vh] bg-popover border-border">
-        <CardHeader className="border-b border-border">
+      <Card className="w-full max-w-4xl h-[80vh] bg-popover border-border admin-modal-card">
+        <CardHeader className="border-b border-border admin-modal-header relative pl-12">
+          <button
+            onClick={onClose}
+            aria-label="إغلاق"
+            title="إغلاق"
+            className="absolute left-3 top-3 px-2 py-1 hover:bg-red-100 text-red-600 text-sm font-medium rounded"
+          >
+            ✖️
+          </button>
           <div className="flex items-center justify-between">
             <CardTitle className="text-xl text-gray-100 flex items-center gap-2">
               <Shield className="w-6 h-6 text-yellow-400" />
@@ -170,9 +178,6 @@ export default function ActiveModerationLog({
               <Badge variant="outline" className="text-blue-400 border-blue-400">
                 {currentUser.userType === 'owner' ? 'المالك' : 'مشرف'}
               </Badge>
-              <Button onClick={onClose} variant="ghost" size="sm">
-                ✕
-              </Button>
             </div>
           </div>
         </CardHeader>

--- a/client/src/components/moderation/PromoteUserPanel.tsx
+++ b/client/src/components/moderation/PromoteUserPanel.tsx
@@ -220,8 +220,16 @@ export default function PromoteUserPanel({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-2xl max-h-[85vh] bg-popover border-border flex flex-col">
-        <CardHeader className="border-b border-border">
+      <Card className="w-full max-w-2xl max-h-[85vh] bg-popover border-border flex flex-col admin-modal-card">
+        <CardHeader className="border-b border-border admin-modal-header relative pl-12">
+          <button
+            onClick={onClose}
+            aria-label="إغلاق"
+            title="إغلاق"
+            className="absolute left-3 top-3 px-2 py-1 hover:bg-red-100 text-red-600 text-sm font-medium rounded"
+          >
+            ✖️
+          </button>
           <CardTitle className="text-xl text-gray-100 flex items-center gap-2">
             <UserCheck className="w-6 h-6 text-blue-400" />
             ترقية المستخدمين

--- a/client/src/components/moderation/ReportsLog.tsx
+++ b/client/src/components/moderation/ReportsLog.tsx
@@ -186,8 +186,16 @@ export default function ReportsLog({ currentUser, isVisible, onClose }: ReportsL
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-4xl h-[80vh] bg-popover border-border">
-        <CardHeader className="border-b border-border">
+      <Card className="w-full max-w-4xl h-[80vh] bg-popover border-border admin-modal-card">
+        <CardHeader className="border-b border-border admin-modal-header relative pl-12">
+          <button
+            onClick={onClose}
+            aria-label="إغلاق"
+            title="إغلاق"
+            className="absolute left-3 top-3 px-2 py-1 hover:bg-red-100 text-red-600 text-sm font-medium rounded"
+          >
+            ✖️
+          </button>
           <div className="flex items-center justify-between">
             <CardTitle className="text-xl text-gray-100 flex items-center gap-2">
               <AlertTriangle className="w-6 h-6 text-red-400" />
@@ -202,9 +210,6 @@ export default function ReportsLog({ currentUser, isVisible, onClose }: ReportsL
               <Badge variant="outline" className="text-blue-400 border-blue-400">
                 {currentUser.userType === 'owner' ? 'المالك' : 'مشرف'}
               </Badge>
-              <Button onClick={onClose} variant="ghost" size="sm">
-                ✕
-              </Button>
             </div>
           </div>
         </CardHeader>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2364,6 +2364,11 @@ li > * > div.effect-crystal {
   background-color: rgba(255, 255, 255, 0.08) !important;
 }
 
+/* Admin modals (Reports, Active Actions, Promote User) top bar unification on berryCool */
+[data-theme-id="berryCool"] .admin-modal-header {
+  background-color: #000000 !important; /* pure black to match other top bars */
+}
+
 /* Modern Loading States */
 .loading-shimmer {
   background: linear-gradient(90deg, 


### PR DESCRIPTION
Standardize the top bar color and close button placement for admin modals in the berryCool theme.

The top bar of the 'Reports Log', 'Active Moderation Log', and 'Promote User Panel' modals now matches the pure black of other top navigation menus in the berryCool theme, and their close buttons are moved to the left for consistency with other dialogs.

---
<a href="https://cursor.com/background-agent?bcId=bc-7e93f492-c051-488e-a517-fe4ad149fa0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7e93f492-c051-488e-a517-fe4ad149fa0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

