### PR TITLE
Fix chat ui and menu colors

### DIFF
--- a/client/src/components/chat/AdminReportsPanel.tsx
+++ b/client/src/components/chat/AdminReportsPanel.tsx
@@ -115,8 +115,8 @@ export default function AdminReportsPanel({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="sm:max-w-[800px] max-h-[600px] overflow-hidden" dir="rtl">
-        <DialogHeader>
+      <DialogContent className="sm:max-w-[800px] max-h-[600px] overflow-hidden bg-popover border border-border admin-modal-card" dir="rtl">
+        <DialogHeader className="admin-modal-header border-b border-border">
           <DialogTitle>لوحة إدارة التبليغات</DialogTitle>
           <DialogDescription>مراجعة التبليغات وإدارة نظام مكافحة السبام</DialogDescription>
         </DialogHeader>

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1140,7 +1140,7 @@ export default function MessageArea({
                 onKeyDown={handleKeyPress}
                 onPaste={handlePaste}
                 placeholder={!currentUser || isChatRestricted ? (getRestrictionMessage || 'هذه الخاصية غير متوفرة الآن') : "اكتب هنا..."}
-                className={`rooms-message-input w-full bg-white text-foreground placeholder:text-muted-foreground rounded-lg border border-gray-300 h-10 pr-3 pl-10 focus:border-transparent focus:ring-offset-0 focus-visible:ring-offset-0 text-[14px]`}
+                className={`rooms-message-input w-full bg-white text-foreground placeholder:text-muted-foreground rounded-lg border border-gray-300 h-10 pr-10 pl-3 focus:border-transparent focus:ring-offset-0 focus-visible:ring-offset-0 text-[14px]`}
                 disabled={!currentUser || isChatRestricted}
                 style={{ color: composerTextColor, fontWeight: composerBold ? 700 : undefined }}
                 maxLength={MAX_CHARS}
@@ -1154,7 +1154,7 @@ export default function MessageArea({
                   setShowEmojiMart(false);
                   setShowLottieEmoji(false);
                 }}
-                className="absolute inset-y-0 left-2 my-auto h-6 w-6 flex items-center justify-center text-gray-500 hover:text-gray-700"
+                className="absolute inset-y-0 right-2 my-auto h-6 w-6 flex items-center justify-center chat-emoji-button text-gray-500 hover:text-gray-700"
                 title="إظهار السمايلات"
                 disabled={!currentUser || isChatRestricted}
               >
@@ -1163,7 +1163,7 @@ export default function MessageArea({
 
               {/* Emoji pickers anchored to input container */}
               {showEnhancedEmoji && (
-                <div className="absolute bottom-full left-0 mb-2 z-30">
+                <div className="absolute bottom-full right-0 mb-2 z-30">
                   <React.Suspense fallback={null}>
                     <AnimatedEmojiEnhanced
                       onEmojiSelect={handleEnhancedEmojiSelect}
@@ -1173,7 +1173,7 @@ export default function MessageArea({
                 </div>
               )}
               {showAnimatedEmojiPicker && (
-                <div className="absolute bottom-full left-0 mb-2 z-30">
+                <div className="absolute bottom-full right-0 mb-2 z-30">
                   <React.Suspense fallback={null}>
                     <AnimatedEmojiPicker
                       onEmojiSelect={handleAnimatedEmojiSelect}
@@ -1183,7 +1183,7 @@ export default function MessageArea({
                 </div>
               )}
               {showEmojiMart && (
-                <div className="absolute bottom-full left-0 mb-2 z-30">
+                <div className="absolute bottom-full right-0 mb-2 z-30">
                   <React.Suspense fallback={null}>
                     <EmojiMartPicker
                       onEmojiSelect={handleEmojiMartSelect}
@@ -1193,7 +1193,7 @@ export default function MessageArea({
                 </div>
               )}
               {showLottieEmoji && (
-                <div className="absolute bottom-full left-0 mb-2 z-30">
+                <div className="absolute bottom-full right-0 mb-2 z-30">
                   <React.Suspense fallback={null}>
                     <LottieEmojiPicker
                       onEmojiSelect={handleLottieEmojiSelect}

--- a/client/src/components/moderation/ActiveModerationLog.tsx
+++ b/client/src/components/moderation/ActiveModerationLog.tsx
@@ -154,7 +154,7 @@ export default function ActiveModerationLog({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-4xl h-[80vh] bg-popover border-border admin-modal-card">
+      <Card className="w-full max-w-4xl h-[80vh] bg-popover border border-border admin-modal-card">
         <CardHeader className="border-b border-border admin-modal-header relative pl-12">
           <button
             onClick={onClose}

--- a/client/src/components/moderation/PromoteUserPanel.tsx
+++ b/client/src/components/moderation/PromoteUserPanel.tsx
@@ -220,7 +220,7 @@ export default function PromoteUserPanel({
 
   return (
     <div className="fixed inset-0 bg-black/50 backdrop-blur-sm z-50 flex items-center justify-center p-4">
-      <Card className="w-full max-w-2xl max-h-[85vh] bg-popover border-border flex flex-col admin-modal-card">
+      <Card className="w-full max-w-2xl max-h-[85vh] bg-popover border border-border flex flex-col admin-modal-card">
         <CardHeader className="border-b border-border admin-modal-header relative pl-12">
           <button
             onClick={onClose}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2364,9 +2364,9 @@ li > * > div.effect-crystal {
   background-color: rgba(255, 255, 255, 0.08) !important;
 }
 
-/* Admin modals (Reports, Active Actions, Promote User) top bar unification on berryCool */
-[data-theme-id="berryCool"] .admin-modal-header {
-  background-color: #000000 !important; /* pure black to match other top bars */
+/* Admin modals (Reports, Active Actions, Promote User) top bar unified: use solid black like top bars */
+.admin-modal-header {
+  background-color: #000000 !important;
 }
 
 /* Modern Loading States */


### PR DESCRIPTION
Align chat emoji button and pickers to the right and unify admin panel header colors to black.

The emoji button was on the left and its picker opened far away, hindering usability. Admin panel headers had inconsistent coloring (black top, navy bottom), which is now unified to solid black for a consistent look.

---
<a href="https://cursor.com/background-agent?bcId=bc-239cdfe8-9e44-4be7-98d9-3a33368a1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-239cdfe8-9e44-4be7-98d9-3a33368a1039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

