### PR TITLE
Adjust chat UI colors and layout

### DIFF
--- a/client/src/components/chat/ComposerPlusMenu.tsx
+++ b/client/src/components/chat/ComposerPlusMenu.tsx
@@ -1,91 +1,27 @@
 import React from 'react';
-import { Plus, Image, Bold, Palette } from 'lucide-react';
+import { Plus } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuSub,
-  DropdownMenuSubContent,
-  DropdownMenuSubTrigger,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
-import { useComposerStyle } from '@/contexts/ComposerStyleContext';
 
 interface ComposerPlusMenuProps {
-  onOpenImagePicker?: () => void;
+  onOpenImagePicker?: () => void; // intentionally unused after simplification
   disabled?: boolean;
   isMobile?: boolean;
-  currentUser?: any; // إضافة المستخدم الحالي للتحقق من الصلاحيات
+  currentUser?: any; // intentionally unused
 }
 
-export default function ComposerPlusMenu({ onOpenImagePicker, disabled, isMobile, currentUser }: ComposerPlusMenuProps) {
-  const { toggleBold, setTextColor, palette, bold } = useComposerStyle();
-
-  // التحقق من الصلاحيات
-  const isAuthorized = currentUser && (
-    currentUser.userType === 'owner' || 
-    currentUser.userType === 'admin' || 
-    currentUser.userType === 'moderator'
-  );
-
+export default function ComposerPlusMenu({ disabled, isMobile }: ComposerPlusMenuProps) {
+  // تبويب الزائد مبسّط: أيقونة + فقط بدون قائمة
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="outline"
-          size={isMobile ? 'icon' : 'icon'}
-          disabled={disabled}
-          className={`chat-plus-button mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 border border-input bg-background text-foreground hover:bg-accent hover:text-accent-foreground`}
-          title="خيارات"
-          aria-label="زر الخيارات"
-        >
-          <Plus className={`${isMobile ? 'w-6 h-6' : 'w-5 h-5'} shrink-0`} strokeWidth={2.25} />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="min-w-[12rem] bg-popover text-popover-foreground border border-border">
-        <DropdownMenuLabel>خيارات إضافية</DropdownMenuLabel>
-        {isAuthorized && (
-          <DropdownMenuItem onClick={() => onOpenImagePicker && onOpenImagePicker()}>
-            <Image className="w-4 h-4 ml-2" />
-            إرسال صورة
-          </DropdownMenuItem>
-        )}
-        {!isAuthorized && (
-          <DropdownMenuItem disabled className="opacity-50">
-            <Image className="w-4 h-4 ml-2" />
-            إرسال صورة (للمشرفين فقط)
-          </DropdownMenuItem>
-        )}
-        <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={toggleBold}>
-          <Bold className="w-4 h-4 ml-2" />
-          نص غامق {bold ? '✔️' : ''}
-        </DropdownMenuItem>
-        <DropdownMenuSub>
-          <DropdownMenuSubTrigger>
-            <Palette className="w-4 h-4 ml-2" />
-            لون النص
-          </DropdownMenuSubTrigger>
-          <DropdownMenuSubContent className="p-2">
-            <div className="grid grid-cols-6 gap-2">
-              {palette.map((color) => (
-                <button
-                  key={color}
-                  onClick={() => setTextColor(color)}
-                  className="w-5 h-5 rounded border border-gray-300 hover:scale-110 transition-transform"
-                  style={{ backgroundColor: color }}
-                  title={color}
-                />
-              ))}
-            </div>
-          </DropdownMenuSubContent>
-        </DropdownMenuSub>
-      </DropdownMenuContent>
-    </DropdownMenu>
+    <Button
+      type="button"
+      size={isMobile ? 'icon' : 'icon'}
+      disabled={disabled}
+      className={`chat-plus-button mobile-touch-button ${isMobile ? 'h-11 w-11' : 'h-10 w-10'} rounded-lg px-0 bg-primary text-primary-foreground hover:bg-primary/90 border-0`}
+      title="إضافة"
+      aria-label="إضافة"
+    >
+      <Plus className={`${isMobile ? 'w-6 h-6' : 'w-5 h-5'} shrink-0`} strokeWidth={2.25} />
+    </Button>
   );
 }

--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -1125,7 +1125,7 @@ export default function MessageArea({
             <Button
               onClick={handleSendMessage}
               disabled={!messageText.trim() || !currentUser || isChatRestricted}
-              className={`aspect-square bg-primary hover:bg-primary/90 text-primary-foreground rounded-full mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''} ${isChatRestricted ? 'opacity-60 cursor-not-allowed' : ''}`}
+              className={`chat-send-button aspect-square bg-primary hover:bg-primary/90 text-primary-foreground rounded-full mobile-touch-button ${isMobile ? 'min-w-[44px] min-h-[44px]' : ''}`}
               title="إرسال"
             >
               <Send className="w-4 h-4" />

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2340,17 +2340,33 @@ li > * > div.effect-crystal {
 }
 
 /* ===== Theme-specific overrides for Toti Bard (berryCool) ===== */
-[data-theme-id="berryCool"] .chat-emoji-button,
-[data-theme-id="berryCool"] .chat-plus-button {
-  /* Use send button (primary) color instead of dark/neutral */
+/* Fix send button color: keep consistent pre-typing primary */
+[data-theme-id="berryCool"] .chat-send-button {
   background-color: var(--primary-solid) !important;
   color: var(--primary-foreground) !important;
-  border-color: color-mix(in srgb, var(--primary-solid) 50%, #000) !important;
+}
+[data-theme-id="berryCool"] .chat-send-button:hover {
+  background-color: color-mix(in srgb, var(--primary-solid) 90%, #000) !important;
 }
 
-[data-theme-id="berryCool"] .chat-emoji-button:hover,
+/* Plus tab: icon only and same color as send button */
+[data-theme-id="berryCool"] .chat-plus-button {
+  background-color: var(--primary-solid) !important;
+  color: var(--primary-foreground) !important;
+  border: none !important;
+}
 [data-theme-id="berryCool"] .chat-plus-button:hover {
   background-color: color-mix(in srgb, var(--primary-solid) 90%, #000) !important;
+}
+
+/* Emoji tab: remove blue color, keep neutral icon (no forced color) */
+[data-theme-id="berryCool"] .chat-emoji-button {
+  background-color: transparent !important;
+  color: inherit !important;
+  border-color: var(--border) !important;
+}
+[data-theme-id="berryCool"] .chat-emoji-button:hover {
+  background-color: rgba(255,255,255,0.06) !important;
 }
 
 /* Private messages: make gallery icon white on berryCool */


### PR DESCRIPTION
Standardize chat UI for the berryCool theme by fixing the send button color, simplifying the plus tab, and neutralizing the emoji tab's styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-cb7ccd52-9979-4fcb-bfe7-fa11dca5247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-cb7ccd52-9979-4fcb-bfe7-fa11dca5247b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

