### PR TITLE
Remove blue color from smiley button

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2340,7 +2340,7 @@ li > * > div.effect-crystal {
 }
 
 /* ===== Theme-specific overrides for Toti Bard (berryCool) ===== */
-[data-theme-id="berryCool"] .chat-emoji-button,
+/* Keep primary styling for plus button only; emoji button stays neutral */
 [data-theme-id="berryCool"] .chat-plus-button {
   /* Use send button (primary) color instead of dark/neutral */
   background-color: var(--primary-solid) !important;
@@ -2348,7 +2348,6 @@ li > * > div.effect-crystal {
   border-color: color-mix(in srgb, var(--primary-solid) 50%, #000) !important;
 }
 
-[data-theme-id="berryCool"] .chat-emoji-button:hover,
 [data-theme-id="berryCool"] .chat-plus-button:hover {
   background-color: color-mix(in srgb, var(--primary-solid) 90%, #000) !important;
 }


### PR DESCRIPTION
Remove the blue color from the chat emoji button in the `berryCool` theme.

The user requested to revert the chat emoji button to its default neutral color, removing the blue styling that was being applied specifically in the `berryCool` theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-b6ec5f78-e5ac-4002-8d2d-717d72a05a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b6ec5f78-e5ac-4002-8d2d-717d72a05a0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

