### PR TITLE
Improve text box and message bubble design

### DIFF
--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -566,7 +566,7 @@ export default function PrivateMessageBox({
 
                   return (
                     <div key={key} className={`w-full flex ${alignClass} mb-1`}>
-                      <div className={`max-w-[80%] flex items-end gap-2 ${isMe ? 'flex-row-reverse' : 'flex-row'}`}>
+                      <div className={`max-w-[75%] flex items-end gap-2 ${isMe ? 'flex-row-reverse' : 'flex-row'}`}>
                         {/* Avatar at end of other-user group */}
                         {showAvatar ? (
                           <ProfileImage
@@ -668,53 +668,34 @@ export default function PrivateMessageBox({
                               </span>
                             );
                           })()}
+                          {(() => {
+                            const isLastOutgoing = isMe && index === sortedMessages.length - 1;
+                            if (!isLastOutgoing) return null;
+                            const seen = (() => {
+                              try {
+                                if (!otherLastReadAt) return false;
+                                const lastReadMs = new Date(otherLastReadAt).getTime();
+                                const thisMsgMs = new Date(m.timestamp as any).getTime();
+                                return Number.isFinite(lastReadMs) && Number.isFinite(thisMsgMs) && lastReadMs >= thisMsgMs;
+                              } catch { return false; }
+                            })();
+                            return (
+                              <span className="pm-meta self-end">
+                                <span>{formatTime(m.timestamp)}</span>
+                                {seen ? (
+                                  <CheckCheck className="w-3.5 h-3.5 text-[#dbeafe]" />
+                                ) : (
+                                  <Check className="w-3.5 h-3.5 text-white/70" />
+                                )}
+                              </span>
+                            );
+                          })()}
                         </motion.div>
                       </div>
                     </div>
                   );
                 }}
               />
-            )}
-
-            {/* Time & read receipts under last bubble in each group (Messenger-like) */}
-            {sortedMessages.length > 0 && (
-              <div className="px-12 mt-1 space-y-1">
-                {sortedMessages.map((m, index) => {
-                  const isMe = !!(currentUser && m.senderId === currentUser.id);
-                  const next = index + 1 < sortedMessages.length ? sortedMessages[index + 1] : null;
-                  const groupEnd = !next || !isSameSender(next, m) || !isWithinWindow(next, m);
-                  if (!groupEnd) return null;
-                  const isLastOutgoing = isMe && index === sortedMessages.length - 1;
-                  const seen = (() => {
-                    try {
-                      if (!otherLastReadAt) return false;
-                      const lastReadMs = new Date(otherLastReadAt).getTime();
-                      const thisMsgMs = new Date(m.timestamp as any).getTime();
-                      return Number.isFinite(lastReadMs) && Number.isFinite(thisMsgMs) && lastReadMs >= thisMsgMs;
-                    } catch { return false; }
-                  })();
-                  return (
-                    <React.Fragment key={`meta-${m.id || index}`}>
-                      {isMe ? (
-                        <div className="flex justify-end items-center gap-1">
-                          {isLastOutgoing ? (
-                            seen ? (
-                              <CheckCheck className="w-3.5 h-3.5 text-[#0084ff]" />
-                            ) : (
-                              <Check className="w-3.5 h-3.5 text-gray-400" />
-                            )
-                          ) : null}
-                          <span className="text-[11px] text-gray-500">{formatTime(m.timestamp)}</span>
-                        </div>
-                      ) : (
-                        <div className="flex justify-start">
-                          <span className="text-[11px] text-gray-500">{formatTime(m.timestamp)}</span>
-                        </div>
-                      )}
-                    </React.Fragment>
-                  );
-                })}
-              </div>
             )}
 
             {/* تم إخفاء زر "الانتقال لأسفل" */}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2764,41 +2764,54 @@ li::before {
 .pm-bubble {
   position: relative;
   display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 4px;
   padding: 8px 12px;
-  border-radius: 16px;
+  border-radius: 18px;
   max-width: 100%;
   word-break: break-word;
   overflow-wrap: anywhere;
-  line-height: 1.5;
-  border: 1px solid transparent;
+  line-height: 1.4;
+  font-size: 14px;
 }
 
 .pm-bubble--me {
   background: #0084ff; /* Messenger blue */
   color: #fff;
+  align-items: flex-end;
 }
 
 .pm-bubble--other {
-  background: #f1f0f0; /* Messenger gray */
-  color: #111827; /* gray-900 */
+  background: #e4e6eb; /* Messenger gray */
+  color: #050505; /* Messenger dark text */
 }
 
 /* Rounded corners per group position */
-.pm-bubble--start.pm-bubble--me { border-top-right-radius: 4px; }
-.pm-bubble--end.pm-bubble--me { border-bottom-right-radius: 16px; }
-.pm-bubble--start.pm-bubble--other { border-top-left-radius: 4px; }
-.pm-bubble--end.pm-bubble--other { border-bottom-left-radius: 16px; }
+/* Group rounding (me = right side in LTR visual) */
+.pm-bubble--start.pm-bubble--me { border-top-right-radius: 6px; }
+.pm-bubble--end.pm-bubble--me { border-bottom-right-radius: 18px; }
+.pm-bubble--start.pm-bubble--other { border-top-left-radius: 6px; }
+.pm-bubble--end.pm-bubble--other { border-bottom-left-radius: 18px; }
+
+/* Middle items keep tighter corner on the joined side */
+.pm-bubble--me:not(.pm-bubble--start):not(.pm-bubble--end) {
+  border-top-right-radius: 6px;
+  border-bottom-right-radius: 6px;
+}
+.pm-bubble--other:not(.pm-bubble--start):not(.pm-bubble--end) {
+  border-top-left-radius: 6px;
+  border-bottom-left-radius: 6px;
+}
 
 /* Optional subtle tails (simple pseudo-elements) */
 .pm-bubble--me.pm-bubble--start::after {
   content: '';
   position: absolute;
   right: -4px;
-  top: 8px;
-  width: 8px;
-  height: 8px;
+  top: 10px;
+  width: 10px;
+  height: 10px;
   background: #0084ff;
   transform: rotate(45deg);
   border-top-right-radius: 2px;
@@ -2808,16 +2821,28 @@ li::before {
   content: '';
   position: absolute;
   left: -4px;
-  top: 8px;
-  width: 8px;
-  height: 8px;
-  background: #f1f0f0;
+  top: 10px;
+  width: 10px;
+  height: 10px;
+  background: #e4e6eb;
   transform: rotate(45deg);
   border-top-left-radius: 2px;
 }
 
 /* Ensure message text retains current typography */
-.pm-bubble .ac-message-text { font-weight: 600; font-size: 13px; }
+.pm-bubble .ac-message-text { font-weight: 500; font-size: 14px; }
+
+/* Inline meta (time + ticks) inside bubble for last outgoing */
+.pm-meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  line-height: 1;
+  opacity: 0.9;
+}
+.pm-bubble--me .pm-meta { color: rgba(255,255,255,0.85); }
+.pm-bubble--other .pm-meta { color: #606770; }
 .ch_logs .my_text .cname > .rtl_fright {
   float: none !important;
   white-space: nowrap;


### PR DESCRIPTION
Implement Messenger-style read receipts and simplify private message bubble styling.

This change introduces single and double checkmarks for sent and seen messages, respectively, and removes custom border colors from chat bubbles to align with the user's request for a cleaner, Facebook Messenger-like UI.

---
<a href="https://cursor.com/background-agent?bcId=bc-3dc76920-9f3a-4f4c-bc5e-b2c2bf24a40b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3dc76920-9f3a-4f4c-bc5e-b2c2bf24a40b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

