### PR TITLE
Fix image display and alignment in chat

### DIFF
--- a/client/src/components/chat/MessageArea.tsx
+++ b/client/src/components/chat/MessageArea.tsx
@@ -778,6 +778,39 @@ export default function MessageArea({
                                 ? 'runin-text text-red-600 truncate'
                                 : 'runin-text text-red-600 message-content-fix';
                               const contentStyle = forceSingleLine ? { whiteSpace: 'nowrap' as const } : undefined;
+                              
+                              // Handle image messages in system messages
+                              if (message.messageType === 'image') {
+                                return (
+                                  <div className={contentClass} style={contentStyle}>
+                                    <button
+                                      type="button"
+                                      onClick={() => setImageLightbox({ open: true, src: message.content })}
+                                      className="inline-block p-0 bg-transparent rounded-lg overflow-hidden align-top"
+                                      title="عرض الصورة"
+                                      aria-label="عرض الصورة"
+                                    >
+                                      <img
+                                        src={message.content}
+                                        alt="صورة مرفقة"
+                                        className="block max-w-[200px] max-h-[200px] object-cover rounded-lg"
+                                        loading="lazy"
+                                        decoding="async"
+                                        onError={(e: any) => {
+                                          if (e?.currentTarget) {
+                                            e.currentTarget.style.display = 'none';
+                                            const parent = e.currentTarget.parentElement;
+                                            if (parent) {
+                                              parent.innerHTML = '<div class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded text-xs text-gray-600"><svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"></path></svg>صورة</div>';
+                                            }
+                                          }
+                                        }}
+                                      />
+                                    </button>
+                                  </div>
+                                );
+                              }
+                              
                               return (
                                 <div className={contentClass} style={contentStyle}>
                                   <span className="ac-message-text">{message.content}</span>
@@ -895,11 +928,27 @@ export default function MessageArea({
                                 <button
                                   type="button"
                                   onClick={() => setImageLightbox({ open: true, src: message.content })}
-                                  className="inline-flex items-center justify-center p-0 bg-transparent"
+                                  className="inline-block p-0 bg-transparent rounded-lg overflow-hidden align-top"
                                   title="عرض الصورة"
                                   aria-label="عرض الصورة"
                                 >
-                                  <ImageAttachmentBadge />
+                                  <img
+                                    src={message.content}
+                                    alt="صورة مرفقة"
+                                    className="block max-w-[200px] max-h-[200px] object-cover rounded-lg"
+                                    loading="lazy"
+                                    decoding="async"
+                                    onError={(e: any) => {
+                                      if (e?.currentTarget) {
+                                        e.currentTarget.style.display = 'none';
+                                        // Show fallback badge if image fails to load
+                                        const parent = e.currentTarget.parentElement;
+                                        if (parent) {
+                                          parent.innerHTML = '<div class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded text-xs text-gray-600"><svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"></path></svg>صورة</div>';
+                                        }
+                                      }
+                                    }}
+                                  />
                                 </button>
                               ) : (
                                 (() => {

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -658,7 +658,7 @@ export default function PrivateMessageBox({
                               <button
                                 type="button"
                                 onClick={() => setImageLightbox({ open: true, src: m.content })}
-                                className="p-0 bg-transparent rounded-lg overflow-hidden"
+                                className="p-0 bg-transparent rounded-lg overflow-hidden block"
                                 title="عرض الصورة"
                                 aria-label="عرض الصورة"
                               >
@@ -668,6 +668,15 @@ export default function PrivateMessageBox({
                                   className="block max-w-[220px] max-h-[260px] object-cover rounded-lg"
                                   loading="lazy"
                                   decoding="async"
+                                  onError={(e: any) => {
+                                    if (e?.currentTarget) {
+                                      // Show fallback content if image fails to load
+                                      const parent = e.currentTarget.parentElement;
+                                      if (parent) {
+                                        parent.innerHTML = '<div class="inline-flex items-center gap-1 px-3 py-2 bg-gray-100 rounded-lg text-sm text-gray-600"><svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path fill-rule="evenodd" d="M4 3a2 2 0 00-2 2v10a2 2 0 002 2h12a2 2 0 002-2V5a2 2 0 00-2-2H4zm12 12H4l4-8 3 6 2-4 3 6z" clip-rule="evenodd"></path></svg>صورة غير متوفرة</div>';
+                                      }
+                                    }
+                                  }}
                                 />
                               </button>
                             ) : (() => {

--- a/client/src/components/chat/ProfileImage.tsx
+++ b/client/src/components/chat/ProfileImage.tsx
@@ -71,6 +71,7 @@ export default function ProfileImage({
         sizes={size === 'small' ? '40px' : size === 'large' ? '80px' : '64px'}
         onError={(e: any) => {
           if (e?.currentTarget && e.currentTarget.src !== '/default_avatar.svg') {
+            console.warn(`Failed to load profile image for ${user.username}, falling back to default`);
             e.currentTarget.src = '/default_avatar.svg';
           }
         }}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1591,6 +1591,44 @@ li > * > div.effect-crystal {
   text-align: start; /* يمين في RTL */
 }
 
+/* إصلاح محاذاة الصور مع السطر الأول في الرسائل */
+.message-content-fix img,
+.message-content-fix button img {
+  vertical-align: top;
+  margin-top: 0;
+  margin-bottom: 0;
+  display: inline-block;
+}
+
+/* تحسين محاذاة الصور في الرسائل الخاصة */
+.runin-text img,
+.runin-text button img {
+  vertical-align: top;
+  margin: 0;
+  display: inline-block;
+  line-height: 1;
+}
+
+/* ضمان ظهور الصور بشكل صحيح في كل الرسائل */
+.ac-message-text img {
+  max-width: 200px;
+  max-height: 200px;
+  border-radius: 8px;
+  vertical-align: top;
+  margin: 2px 4px;
+  display: inline-block;
+}
+
+/* إصلاح عرض الصور في الدردشة الخاصة */
+.private-message-container img {
+  max-width: 220px;
+  max-height: 260px;
+  border-radius: 12px;
+  vertical-align: top;
+  display: block;
+  margin: 4px 0;
+}
+
 .message-content-fix .truncate {
   line-height: inherit;
   vertical-align: baseline;


### PR DESCRIPTION
Render actual images and apply correct CSS to fix image display and alignment in chat messages.

Previously, image messages in both public and private chats were displayed as a generic badge or icon instead of the actual image content. This PR replaces the placeholder with `<img>` tags and introduces specific CSS rules to ensure images are correctly rendered, aligned with text (e.g., `vertical-align: top`), and include fallback mechanisms for loading errors, addressing both the display and alignment issues reported by users.

---
<a href="https://cursor.com/background-agent?bcId=bc-90aea296-60cd-4422-98ce-508a72fb0f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-90aea296-60cd-4422-98ce-508a72fb0f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

