### PR TITLE
Debug chat component errors

### DIFF
--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -67,6 +67,9 @@ export default function PrivateMessageBox({
   // Read receipts: last read timestamp received from other user via socket
   const [otherLastReadAt, setOtherLastReadAt] = useState<string | null>(null);
 
+  // محسن: ترتيب الرسائل مع تحسين الأداء
+  const sortedMessages = useMemo(() => sortMessagesAscending(messages || []), [messages]);
+
   // Scroll management for DM: track bottom and enable followOutput
   const [isAtBottom, setIsAtBottom] = useState(true);
   const prevMessagesLenRef = useRef<number>(0);
@@ -215,10 +218,6 @@ export default function PrivateMessageBox({
     }
     return { cleaned, ids };
   }, [extractYouTubeId]);
-
-  // محسن: ترتيب الرسائل مع تحسين الأداء
-  const sortedMessages = useMemo(() => sortMessagesAscending(messages || []), [messages]);
-
   // تجميع الرسائل المتتالية لنفس المرسل ضمن نافذة زمنية قصيرة (مثل Messenger)
   const GROUP_TIME_MS = 5 * 60 * 1000; // 5 دقائق
   const getIsMe = useCallback((m: any) => !!(currentUser && m && m.senderId === currentUser.id), [currentUser]);


### PR DESCRIPTION
Reorder `sortedMessages` definition and add CSP-safe audio fallback to fix initialization and media loading errors.

The `ReferenceError` occurred because `sortedMessages` was used within a `useCallback` hook before its `const` declaration, leading to a Temporal Dead Zone issue. The `NotSupportedError` and CSP violation stemmed from attempting to play a silent `blob:` audio URL for "keep-alive" functionality, which was blocked by the Content Security Policy's `media-src 'self'` directive. The Web Audio API provides a compliant alternative for this purpose.

---
<a href="https://cursor.com/background-agent?bcId=bc-99b20c11-ad38-4020-a007-520fbf021998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-99b20c11-ad38-4020-a007-520fbf021998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

