### PR TITLE
Remove tire rotation code from contacts

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -2460,6 +2460,14 @@ li::before {
   display: none !important;
 }
 
+/* Disable VIP frame rotation specifically in the online users list */
+.users-list-reset .vip-frame-overlay {
+  animation: none !important;
+}
+.users-list-reset .vip-frame.base::before {
+  animation: none !important;
+}
+
 /* ===== Arabic.chat-like typography ===== */
 /* Username in user list: bold, slightly larger, Cairo */
 .ac-user-name {


### PR DESCRIPTION
Disable VIP frame rotation in the online users list.

The user reported that frames in the contacts list were spinning, and requested to remove the rotation animation specifically from that list. This change targets the `vip-frame` elements within the `users-list-reset` container to override their animation.

---
<a href="https://cursor.com/background-agent?bcId=bc-30ec1adc-b946-4ffb-82c7-a244193b1dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-30ec1adc-b946-4ffb-82c7-a244193b1dfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

