### PR TITLE
Adjust bounding box to image edges

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1434,6 +1434,9 @@ li > * > div.effect-crystal {
   z-index: 3;
   /* تعطيل أي دوران */
   animation: none !important;
+  /* كبّر الإطار قليلاً ليجلس على حافة الصورة تماماً */
+  transform-origin: center center;
+  transform: scale(var(--vip-overlay-scale, 1.06));
 }
 
 /* Shared rotating border */


### PR DESCRIPTION
Enlarge the VIP frame overlay to make it sit exactly on the image edges.

---
<a href="https://cursor.com/background-agent?bcId=bc-62e7ccaa-e3fb-4483-9889-df13745c2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-62e7ccaa-e3fb-4483-9889-df13745c2569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

