### PR TITLE
Monitor abd-app logs for connection and errors

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -2,13 +2,17 @@ module.exports = {
   apps: [{
     name: 'chat-app',
     script: './dist/index.js',
-    instances: 'max', // استخدم جميع الأنوية المتاحة
+    // تقليل عدد العمليات لتجنب استنزاف اتصالات قاعدة البيانات
+    instances: process.env.PM2_INSTANCES || 2,
     exec_mode: 'cluster', // تشغيل بنمط Cluster لتحمل اتصالات أكثر
     node_args: '--expose-gc --max-old-space-size=400',
     env: {
       NODE_ENV: 'production',
       PORT: 10000,
-      BACKLOG: 8192
+      BACKLOG: 8192,
+      // حدود اتصال قاعدة البيانات الآمنة لكل عملية
+      DB_POOL_MAX: process.env.DB_POOL_MAX || 10,
+      DB_POOL_MIN: process.env.DB_POOL_MIN || 0
     },
     max_memory_restart: '400M',
     error_file: './logs/err.log',


### PR DESCRIPTION
Adjust database connection pool defaults and Socket.IO authentication to prevent "Max client connections reached" errors and rapid client disconnects.

The previous database pool settings (max 8000, min 20) were too high for individual application instances, especially when running multiple processes with PM2, leading to database connection exhaustion. The immediate Socket.IO disconnect on authentication failure caused clients to enter a rapid connect/disconnect loop. This PR reduces default pool sizes to safer limits and introduces a grace period for Socket.IO authentication to allow clients to re-authenticate without immediate disconnection.

---
<a href="https://cursor.com/background-agent?bcId=bc-d400c4df-6e7a-4cc0-af3d-eb46642cdff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d400c4df-6e7a-4cc0-af3d-eb46642cdff1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

