### PR TITLE
Adjust profile picture frame

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -3195,9 +3195,11 @@ export default function ProfileModal({
                       position: 'absolute', 
                       top: '50%',
                       left: '50%',
+                      right: 'auto',
+                      bottom: 'auto',
                       transform: 'translate(-50%, -50%)',
-                      width: '100%', 
-                      height: '100%', 
+                      width: '130px',
+                      height: '130px',
                       objectFit: 'contain', /* للحفاظ على نسب الإطار */
                       pointerEvents: 'none',
                       zIndex: 2


### PR DESCRIPTION
Adjust the VIP frame overlay to correctly fit and center around the 130x130px profile picture in the profile modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a829538-24fe-445d-bb48-014036252569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a829538-24fe-445d-bb48-014036252569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

