### PR TITLE
Fix image aspect ratio for centering

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1437,6 +1437,15 @@ li > * > div.effect-crystal {
   /* إزالة التكبير لأن الـ container الآن أكبر */
   transform-origin: center center;
   transform: scale(1);
+  /* اجعل مركز الإطار دائماً فارغاً فوق الصورة الشخصية */
+  -webkit-mask-image: radial-gradient(circle at center,
+    transparent var(--vip-hole-size, 45%),
+    #fff calc(var(--vip-hole-size, 45%) + 0.5px)
+  );
+  mask-image: radial-gradient(circle at center,
+    transparent var(--vip-hole-size, 45%),
+    #fff calc(var(--vip-hole-size, 45%) + 0.5px)
+  );
 }
 
 /* Shared rotating border */


### PR DESCRIPTION
Fix the `vip-frame-overlay` to correctly display the profile picture through a transparent center.

The previous implementation of the frame overlay was covering the profile picture in the center, instead of creating a transparent hole to show it. This change uses `mask-image` with a `radial-gradient` to ensure the center of the frame is always transparent, allowing the avatar to be visible.

---
<a href="https://cursor.com/background-agent?bcId=bc-12b27841-b765-407c-82a4-131551ecaac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-12b27841-b765-407c-82a4-131551ecaac1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

