### PR TITLE
Process friend data

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1425,7 +1425,7 @@ li > * > div.effect-crystal {
 }
 .vip-frame-overlay {
   position: absolute;
-  inset: 0; /* اجعل الإطار يطابق حجم الصورة تماماً */
+  inset: 0; /* الإطار داخل الصورة الشخصية تماماً */
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1434,18 +1434,18 @@ li > * > div.effect-crystal {
   z-index: 3;
   /* تعطيل أي دوران */
   animation: none !important;
-  /* إزالة التكبير لأن الـ container الآن أكبر */
+  /* الإطار داخل الصورة بدون تكبير */
   transform-origin: center center;
   transform: scale(1);
 }
 
-/* Shared rotating border */
+/* Shared rotating border - داخل الصورة الشخصية */
 .vip-frame.base::before {
   content: '';
   position: absolute;
-  inset: -2px;
+  inset: 0; /* الإطار داخل الصورة بدلاً من خارجها */
   border-radius: 9999px;
-  z-index: 1;
+  z-index: 3;
   padding: 2px; /* frame thickness */
   -webkit-mask:
     linear-gradient(#000 0 0) content-box,


### PR DESCRIPTION
Move VIP frames (image and gradient) to be strictly inside the profile picture.

The user requested to position the frame *within* the profile image without altering its size or any other aspect. Previously, the gradient frame (`.vip-frame.base::before`) was positioned with `inset: -2px`, placing it slightly outside the image. This PR adjusts the `inset` to `0` and updates the `z-index` to ensure it appears correctly inside.

---
<a href="https://cursor.com/background-agent?bcId=bc-1003f123-41a8-4905-aa05-6f3703a9bada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1003f123-41a8-4905-aa05-6f3703a9bada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

