### PR TITLE
Check image visibility

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1426,7 +1426,7 @@ li > * > div.effect-crystal {
 .vip-frame-overlay {
   position: absolute;
   top: 0;
-  right: 0; /* تحريك الإطار لليمين */
+  right: -15px; /* تحريك الإطار لليمين أكثر */
   width: 100%;
   height: 100%;
   object-fit: cover;
@@ -1445,7 +1445,7 @@ li > * > div.effect-crystal {
   content: '';
   position: absolute;
   top: 0;
-  right: 0; /* تحريك الإطار لليمين */
+  right: -15px; /* تحريك الإطار لليمين أكثر */
   width: 100%;
   height: 100%;
   border-radius: 9999px;


### PR DESCRIPTION
Move the golden frame 15 pixels to the right by adjusting the `right` CSS property for `.vip-frame-overlay` and `.vip-frame.base::before`.

This change shifts the frame to cover the right-side profile picture without altering its size, as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-baf402ab-b435-415f-aa4c-e2a51d1e5020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-baf402ab-b435-415f-aa4c-e2a51d1e5020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

