### PR TITLE
Move profile picture and frame to right

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2249,7 +2249,7 @@ export default function ProfileModal({
           overflow: visible; /* السماح للإطار بالظهور خارج الحدود */
           position: absolute;
           top: calc(100% - 195px); /* تحريك للأعلى بمقدار 30px */
-          right: 70px; /* تحريك لليمين بمقدار 40px */
+          right: 0; /* محاذاة حافة الصورة مع نهاية الغلاف اليمنى */
           background-color: transparent;
           box-shadow: none; /* إزالة الظل من الـ container */
           z-index: 2;
@@ -2888,7 +2888,7 @@ export default function ProfileModal({
             width: 160px;
             height: 160px;
             top: calc(100% - 160px);
-            right: 55px; /* على اليمين للموبايل */
+            right: 0; /* محاذاة مع يمين الغلاف على الجوال */
             border-radius: 12px; /* زوايا مدورة قليلاً للأجهزة المحمولة */
           }
           


### PR DESCRIPTION
Align profile picture and frame to the right edge of the cover in the profile modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-94f46404-7ec4-4648-b30b-a07b6548c145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-94f46404-7ec4-4648-b30b-a07b6548c145"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

