### PR TITLE
Shift profile picture and frame right

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2249,7 +2249,7 @@ export default function ProfileModal({
           overflow: visible; /* السماح للإطار بالظهور خارج الحدود */
           position: absolute;
           top: calc(100% - 180px); /* تحريك للأعلى بمقدار 45px لمحاذاة منتصف الزر */
-          right: 50px; /* نقل الصورة الشخصية إلى اليمين أكثر */
+          right: 90px; /* نقل الصورة الشخصية إلى اليمين أكثر */
           background-color: transparent;
           box-shadow: none; /* إزالة الظل من الـ container */
           z-index: 2;
@@ -2271,7 +2271,7 @@ export default function ProfileModal({
         .change-avatar-btn {
           position: absolute;
           top: calc(100% - 55px); /* رفع الزر للأعلى بمقدار 15px */
-          right: 90px; /* تعديل الموضع ليتناسب مع الـ container الجديد */
+          right: 130px; /* تعديل الموضع ليتناسب مع الـ container الجديد */
           background: rgba(0,0,0,0.8);
           border-radius: 50%;
           width: 30px;
@@ -2888,13 +2888,13 @@ export default function ProfileModal({
             width: 160px;
             height: 160px;
             top: calc(100% - 160px);
-            right: 15px; /* نقل الصورة الشخصية إلى اليمين للموبايل */
+            right: 45px; /* نقل الصورة الشخصية إلى اليمين للموبايل */
             border-radius: 12px; /* زوايا مدورة قليلاً للأجهزة المحمولة */
           }
           
           .change-avatar-btn {
             top: calc(100% - 35px);
-            right: 52px; /* تعديل للموبايل */
+            right: 82px; /* تعديل للموبايل */
             width: 25px;
             height: 25px;
             line-height: 25px;


### PR DESCRIPTION
Shift the profile picture and its change button to the right on both desktop and mobile views.

---
<a href="https://cursor.com/background-agent?bcId=bc-0592302c-3b74-4f22-81b7-b60954be56f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-0592302c-3b74-4f22-81b7-b60954be56f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

