### PR TITLE
Adjust profile picture position for mobile

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -2888,15 +2888,17 @@ export default function ProfileModal({
             width: 160px;
             height: 160px;
             top: calc(100% - 160px);
-            right: 45px; /* نقل الصورة الشخصية إلى اليمين للموبايل */
+            right: 5px; /* نقل الصورة الشخصية إلى اليمين للموبايل */
             border-radius: 12px; /* زوايا مدورة قليلاً للأجهزة المحمولة */
+            z-index: 10; /* جعل الصورة تتعدى الزر */
           }
           
           .change-avatar-btn {
             top: calc(100% - 35px);
-            right: 82px; /* تعديل للموبايل */
+            right: 42px; /* تعديل للموبايل */
             width: 25px;
             height: 25px;
+            z-index: 5; /* جعل الزر تحت الصورة */
             line-height: 25px;
             font-size: 12px;
           }


### PR DESCRIPTION
Move profile picture and its change button to the right on mobile and ensure the picture overlaps the button.

---
<a href="https://cursor.com/background-agent?bcId=bc-33a30fe4-9078-42c1-910f-48414be79fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-33a30fe4-9078-42c1-910f-48414be79fba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

