### PR TITLE
Reduce user container height for frame-only users

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -555,6 +555,10 @@ export default function UnifiedSidebar({
     () =>
       React.memo(({ user }: { user: ChatUser }) => {
         if (!user?.username || !user?.userType) return null;
+        
+        // التحقق من وجود إطار للمستخدم
+        const hasFrame = !!(user as any)?.profileFrame;
+        
         return (
           <div key={user.id} className="relative" role="listitem">
             <SimpleUserMenu
@@ -563,15 +567,15 @@ export default function UnifiedSidebar({
               showModerationActions={isModerator}
             >
               <div
-                className={`flex items-center gap-2 py-1.5 px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
+                className={`flex items-center gap-2 ${hasFrame ? 'py-1.5' : 'py-0.5'} px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
                 style={getUserListItemStyles(user)}
                 onClick={(e) => handleUserClick(e as any, user)}
               >
                 {/* حاوية الصورة - حجم ثابت مع محاذاة مركزية */}
                 <div style={{ 
                   marginLeft: 4, 
-                  width: 54,  // حجم ثابت لجميع الحالات
-                  height: 54,
+                  width: hasFrame ? 54 : 46,  // تقليل العرض للمستخدمين بدون إطار
+                  height: hasFrame ? 54 : 46, // تقليل الارتفاع للمستخدمين بدون إطار
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',


### PR DESCRIPTION
Reduce the height of user containers without a profile frame in the user list.

This change specifically targets users without a `profileFrame` to decrease their vertical footprint in the user list, while maintaining the original size for users who have a frame.

---
<a href="https://cursor.com/background-agent?bcId=bc-3d299705-067a-48c8-89e5-cd1a64e612f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3d299705-067a-48c8-89e5-cd1a64e612f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

