### PR TITLE
Fix rich and walls tab frames

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -790,16 +790,26 @@ export default function UnifiedSidebar({
                     <Card key={post.id} className="border border-border wall-post-card">
                       <CardHeader className="pb-3">
                         <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 rounded-full overflow-hidden bg-muted/20 flex items-center justify-center">
-                            {post.userProfileImage ? (
-                              <img
-                                src={getImageSrc(post.userProfileImage)}
-                                alt={post.username}
-                                className="w-full h-full object-cover"
-                              />
-                            ) : (
-                              <span className="text-xs">{post.username.charAt(0)}</span>
-                            )}
+                          <div style={{ 
+                            width: (post as any)?.userProfileFrame ? 43 : 32, 
+                            height: (post as any)?.userProfileFrame ? 43 : 32,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0
+                          }}>
+                            <ProfileImage 
+                              user={{
+                                id: post.userId,
+                                username: post.username,
+                                userType: post.userRole || 'member',
+                                profileImage: post.userProfileImage,
+                                profileFrame: (post as any)?.userProfileFrame,
+                              } as ChatUser}
+                              size="small"
+                              pixelSize={32}
+                              hideRoleBadgeOverlay={true}
+                            />
                           </div>
                           <div className="flex-1">
                             <div className="flex items-center gap-2">
@@ -923,16 +933,26 @@ export default function UnifiedSidebar({
                     <Card key={post.id} className="border border-border wall-post-card">
                       <CardHeader className="pb-3">
                         <div className="flex items-center gap-3">
-                          <div className="w-8 h-8 rounded-full overflow-hidden bg-muted/20 flex items-center justify-center">
-                            {post.userProfileImage ? (
-                              <img
-                                src={getImageSrc(post.userProfileImage)}
-                                alt={post.username}
-                                className="w-full h-full object-cover"
-                              />
-                            ) : (
-                              <span className="text-xs">{post.username.charAt(0)}</span>
-                            )}
+                          <div style={{ 
+                            width: (post as any)?.userProfileFrame ? 43 : 32, 
+                            height: (post as any)?.userProfileFrame ? 43 : 32,
+                            display: 'flex',
+                            alignItems: 'center',
+                            justifyContent: 'center',
+                            flexShrink: 0
+                          }}>
+                            <ProfileImage 
+                              user={{
+                                id: post.userId,
+                                username: post.username,
+                                userType: post.userRole || 'member',
+                                profileImage: post.userProfileImage,
+                                profileFrame: (post as any)?.userProfileFrame,
+                              } as ChatUser}
+                              size="small"
+                              pixelSize={32}
+                              hideRoleBadgeOverlay={true}
+                            />
                           </div>
                           <div className="flex-1">
                             <div className="flex items-center gap-2">

--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -283,7 +283,14 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
                         {idx + 1}
                       </span>
                     )}
-                    <div style={{ width: 40, height: 40 }}>
+                    <div style={{ 
+                      width: (u as any)?.profileFrame ? 54 : 40, 
+                      height: (u as any)?.profileFrame ? 54 : 40,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0
+                    }}>
                       <ProfileImage user={u} size="small" pixelSize={40} className="" hideRoleBadgeOverlay={true} />
                     </div>
                     <div className="flex-1">
@@ -328,11 +335,16 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
               <div className="space-y-2 max-h-32 overflow-y-auto overflow-x-hidden">
                 {candidates.map((c) => (
                 <div key={c.id} className="flex items-center gap-2">
-                    <img
-                    src={getImageSrc(c.profileImage || '/default_avatar.svg')}
-                    alt={c.username}
-                    className="w-6 h-6 rounded-full"
-                    />
+                    <div style={{ 
+                      width: (c as any)?.profileFrame ? 32 : 24, 
+                      height: (c as any)?.profileFrame ? 32 : 24,
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                      flexShrink: 0
+                    }}>
+                      <ProfileImage user={c} size="small" pixelSize={24} className="" hideRoleBadgeOverlay={true} />
+                    </div>
                     <div className="flex-1">
                       <span className="ac-user-name" style={{ color: getFinalUsernameColor(c) }} title={c.username}>
                         {c.username}


### PR DESCRIPTION
Add profile frames to users in the RichestModal and UserSidebarWithWalls components.

This change ensures that user profile frames are displayed consistently across the application, dynamically adjusting container sizes to accommodate frames without unnecessary enlargement.

---
<a href="https://cursor.com/background-agent?bcId=bc-e0f67418-2891-4c9f-b145-aa64dc96d885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e0f67418-2891-4c9f-b145-aa64dc96d885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

