### PR TITLE
Fix profile frame visibility for all users

### DIFF
--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -3168,7 +3168,17 @@ export default function ProfileModal({
             )}
 
             <div className="profile-avatar">
-              {localUser?.profileFrame ? (
+              {(() => {
+                // استخدام نفس منطق ProfileImage للتحقق من صحة الإطار
+                const frameName = localUser?.profileFrame as string | undefined;
+                if (!frameName) return false;
+                const match = String(frameName).match(/(\d+)/);
+                if (match) {
+                  const n = parseInt(match[1]);
+                  return Number.isFinite(n) && n >= 1 && n <= 10;
+                }
+                return false;
+              })() ? (
                 <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                   <ProfileImage 
                     user={localUser} 


### PR DESCRIPTION
Fix profile frame visibility in ProfileModal by aligning its display logic with ProfileImage to correctly render valid frames.

The previous truthiness check (`localUser?.profileFrame ?`) in ProfileModal would evaluate to true even for `frame0.webp`, which signifies no frame. This prevented valid frames from being displayed correctly for other users. The updated logic now accurately checks for valid frame numbers (1-10), ensuring frames are shown only when intended.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fabd172-02ef-4fc1-8755-b682373af590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8fabd172-02ef-4fc1-8755-b682373af590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

