### PR TITLE
Fix vip frame display on walls

### DIFF
--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -790,27 +790,29 @@ export default function UnifiedSidebar({
                     <Card key={post.id} className="border border-border wall-post-card">
                       <CardHeader className="pb-3">
                         <div className="flex items-center gap-3">
-                          <div style={{ 
-                            width: (post as any)?.userProfileFrame ? 43 : 32, 
-                            height: (post as any)?.userProfileFrame ? 43 : 32,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0
-                          }}>
-                            <ProfileImage 
-                              user={{
-                                id: post.userId,
-                                username: post.username,
-                                userType: post.userRole || 'member',
-                                profileImage: post.userProfileImage,
-                                profileFrame: (post as any)?.userProfileFrame,
-                              } as ChatUser}
-                              size="small"
-                              pixelSize={32}
-                              hideRoleBadgeOverlay={true}
-                            />
-                          </div>
+                          {(() => {
+                            const frameFromPost = (post as any)?.userProfileFrame as string | undefined;
+                            const effectiveUser: ChatUser = {
+                              id: post.userId,
+                              username: post.username,
+                              userType: post.userRole || 'member',
+                              profileImage: post.userProfileImage,
+                              usernameColor: post.usernameColor,
+                            } as ChatUser;
+                            if (frameFromPost) (effectiveUser as any).profileFrame = frameFromPost;
+                            const hasFrame = Boolean((effectiveUser as any)?.profileFrame);
+                            const containerSize = hasFrame ? 43 : 32;
+                            return (
+                              <div style={{ width: containerSize, height: containerSize, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                                <ProfileImage 
+                                  user={effectiveUser}
+                                  size="small"
+                                  pixelSize={32}
+                                  hideRoleBadgeOverlay={true}
+                                />
+                              </div>
+                            );
+                          })()}
                           <div className="flex-1">
                             <div className="flex items-center gap-2">
                               <span
@@ -933,27 +935,29 @@ export default function UnifiedSidebar({
                     <Card key={post.id} className="border border-border wall-post-card">
                       <CardHeader className="pb-3">
                         <div className="flex items-center gap-3">
-                          <div style={{ 
-                            width: (post as any)?.userProfileFrame ? 43 : 32, 
-                            height: (post as any)?.userProfileFrame ? 43 : 32,
-                            display: 'flex',
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                            flexShrink: 0
-                          }}>
-                            <ProfileImage 
-                              user={{
-                                id: post.userId,
-                                username: post.username,
-                                userType: post.userRole || 'member',
-                                profileImage: post.userProfileImage,
-                                profileFrame: (post as any)?.userProfileFrame,
-                              } as ChatUser}
-                              size="small"
-                              pixelSize={32}
-                              hideRoleBadgeOverlay={true}
-                            />
-                          </div>
+                          {(() => {
+                            const frameFromPost = (post as any)?.userProfileFrame as string | undefined;
+                            const effectiveUser: ChatUser = {
+                              id: post.userId,
+                              username: post.username,
+                              userType: post.userRole || 'member',
+                              profileImage: post.userProfileImage,
+                              usernameColor: post.usernameColor,
+                            } as ChatUser;
+                            if (frameFromPost) (effectiveUser as any).profileFrame = frameFromPost;
+                            const hasFrame = Boolean((effectiveUser as any)?.profileFrame);
+                            const containerSize = hasFrame ? 43 : 32;
+                            return (
+                              <div style={{ width: containerSize, height: containerSize, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
+                                <ProfileImage 
+                                  user={effectiveUser}
+                                  size="small"
+                                  pixelSize={32}
+                                  hideRoleBadgeOverlay={true}
+                                />
+                              </div>
+                            );
+                          })()}
                           <div className="flex-1">
                             <div className="flex items-center gap-2">
                               <span

--- a/client/src/components/chat/WallPostList.tsx
+++ b/client/src/components/chat/WallPostList.tsx
@@ -99,22 +99,37 @@ export default function WallPostList({
             <div className="flex items-center justify-between">
               <div className="flex items-center gap-3">
                 <div className="relative">
-                  <div className="w-12 h-12" style={{ width: 48, height: 48 }}>
-                    <ProfileImage 
-                      user={usersData[post.userId] || {
-                        id: post.userId,
-                        username: post.username,
-                        role: (post.userRole as any) || 'member',
-                        userType: post.userRole as any,
-                        isOnline: true,
-                        profileImage: post.userProfileImage,
-                        usernameColor: post.usernameColor,
-                      } as ChatUser} 
-                      size="small" 
-                      className="w-12 h-12" 
-                      hideRoleBadgeOverlay={true} 
-                    />
-                  </div>
+                  {(() => {
+                    const userFromCache = usersData[post.userId];
+                    const frameFromPost = (post as any)?.userProfileFrame as string | undefined;
+                    const effectiveUser: ChatUser = (userFromCache
+                      ? { ...userFromCache }
+                      : {
+                          id: post.userId,
+                          username: post.username,
+                          role: (post.userRole as any) || 'member',
+                          userType: (post.userRole as any) || 'member',
+                          isOnline: true,
+                          profileImage: post.userProfileImage,
+                          usernameColor: post.usernameColor,
+                        }) as ChatUser;
+                    if (!('profileFrame' in (effectiveUser as any)) && frameFromPost) {
+                      (effectiveUser as any).profileFrame = frameFromPost;
+                    }
+                    const hasFrame = Boolean((effectiveUser as any)?.profileFrame);
+                    const containerSize = hasFrame ? 54 : 40; // 40px image, 54px with frame
+                    return (
+                      <div style={{ width: containerSize, height: containerSize, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                        <ProfileImage
+                          user={effectiveUser}
+                          size="small"
+                          pixelSize={40}
+                          className=""
+                          hideRoleBadgeOverlay={true}
+                        />
+                      </div>
+                    );
+                  })()}
                 </div>
                 <div>
                   <div className="flex items-center gap-2">

--- a/migrations/0016_add_user_profile_frame_to_wall_posts.sql
+++ b/migrations/0016_add_user_profile_frame_to_wall_posts.sql
@@ -1,0 +1,3 @@
+-- Add user_profile_frame to wall_posts so VIP frames render on walls
+ALTER TABLE wall_posts
+  ADD COLUMN IF NOT EXISTS user_profile_frame TEXT;

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,7 +111,7 @@
         "zod-validation-error": "^3.4.0"
       },
       "devDependencies": {
-        "@replit/vite-plugin-cartographer": "^0.2.7",
+        "@replit/vite-plugin-cartographer": "^0.2.8",
         "@tailwindcss/typography": "^0.5.15",
         "@tailwindcss/vite": "^4.1.3",
         "@types/connect-pg-simple": "^7.0.3",
@@ -141,7 +141,7 @@
         "prettier": "^3.6.2",
         "socket.io-client": "^4.8.1",
         "tailwindcss": "^3.4.17",
-        "terser": "^5.43.1",
+        "terser": "^5.44.0",
         "tsx": "^4.20.6",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.39.0",
@@ -13852,14 +13852,14 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.43.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.43.1.tgz",
-      "integrity": "sha512-+6erLbBm0+LROX2sPXlUYx/ux5PyE9K/a92Wrt6oA+WDAoFTdpHE5tCYCI5PNzq2y8df4rA+QgHLJuR4jNymsg==",
+      "version": "5.44.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.44.0.tgz",
+      "integrity": "sha512-nIVck8DK+GM/0Frwd+nIhZ84pR/BX7rmXMfYwyg+Sri5oGVE99/E3KvXqpC2xHFxyqXyGHTKBSioxxplrO4I4w==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
-        "acorn": "^8.14.0",
+        "acorn": "^8.15.0",
         "commander": "^2.20.0",
         "source-map-support": "~0.5.20"
       },

--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "zod-validation-error": "^3.4.0"
   },
   "devDependencies": {
-    "@replit/vite-plugin-cartographer": "^0.2.7",
+    "@replit/vite-plugin-cartographer": "^0.2.8",
     "@tailwindcss/typography": "^0.5.15",
     "@tailwindcss/vite": "^4.1.3",
     "@types/connect-pg-simple": "^7.0.3",
@@ -167,7 +167,7 @@
     "prettier": "^3.6.2",
     "socket.io-client": "^4.8.1",
     "tailwindcss": "^3.4.17",
-    "terser": "^5.43.1",
+    "terser": "^5.44.0",
     "tsx": "^4.20.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.39.0",

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -4330,6 +4330,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         type: type || 'public',
         timestamp: new Date(),
         userProfileImage: user.profileImage,
+        // تمرير إطار البروفايل للحائط لعرضه مباشرةً دون قواعد إضافية
+        userProfileFrame: (user as any)?.profileFrame || null,
         usernameColor: user.usernameColor,
       };
 

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -327,6 +327,7 @@ export async function createWallPost(postData: any): Promise<any> {
           type: postData.type ?? 'public',
           timestamp: postData.timestamp ?? new Date(),
           userProfileImage: postData.userProfileImage ?? null,
+          userProfileFrame: postData.userProfileFrame ?? null,
           usernameColor: postData.usernameColor ?? null,
         })
         .returning();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -283,6 +283,8 @@ export const wallPosts = pgTable('wall_posts', {
   type: text('type').notNull().default('public'), // 'public', 'friends'
   timestamp: timestamp('timestamp').defaultNow(),
   userProfileImage: text('user_profile_image'),
+  // إطار المستخدم وقت إنشاء المنشور لضمان عرضه بدون جلب إضافي
+  userProfileFrame: text('user_profile_frame'),
   usernameColor: text('username_color').default('#4A90E2'),
   totalLikes: integer('total_likes').default(0),
   totalDislikes: integer('total_dislikes').default(0),


### PR DESCRIPTION
Display VIP user profile frames on wall posts by storing the frame data with the post and rendering it via `ProfileImage`.

Previously, wall posts did not include the user's profile frame information, preventing the `ProfileImage` component from rendering it. This fix introduces a `user_profile_frame` column to the `wall_posts` table, populates it when a post is created, and updates the client-side wall components to pass this frame data to the `ProfileImage` component for consistent rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-b02bdc9b-d6eb-4413-accd-f1e6355b78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b02bdc9b-d6eb-4413-accd-f1e6355b78e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

