### PR TITLE
Resize profile picture and frame slightly

### DIFF
--- a/client/src/components/chat/MessagesPanel.tsx
+++ b/client/src/components/chat/MessagesPanel.tsx
@@ -385,7 +385,7 @@ export default function MessagesPanel({
                           alignItems: 'center',
                           justifyContent: 'center'
                         }}>
-                          <ProfileImage user={user} size="small" pixelSize={40} hideRoleBadgeOverlay={true} />
+                          <ProfileImage user={user} size="small" pixelSize={36} hideRoleBadgeOverlay={true} />
                         </div>
                         <div className="flex-1 min-w-0 flex flex-col justify-center">
                           <div className="flex items-center justify-between gap-2 w-full">

--- a/client/src/components/chat/PrivateMessageBox.tsx
+++ b/client/src/components/chat/PrivateMessageBox.tsx
@@ -439,7 +439,7 @@ export default function PrivateMessageBox({
                 <ProfileImage
                   user={user}
                   size="small"
-                  pixelSize={40}
+                  pixelSize={36}
                   className="cursor-pointer hover:opacity-90 transition"
                   onClick={handleViewProfileClick}
                 />

--- a/client/src/components/chat/ProfileImage.tsx
+++ b/client/src/components/chat/ProfileImage.tsx
@@ -27,9 +27,9 @@ export default function ProfileImage({
   disableFrame = false,
 }: ProfileImageProps) {
   const sizeClasses = {
-    small: 'w-10 h-10',
-    medium: 'w-16 h-16',
-    large: 'w-20 h-20',
+    small: 'w-9 h-9',
+    medium: 'w-14 h-14',
+    large: 'w-18 h-18',
   };
 
   // تحديد لون الإطار حسب الجنس - كما كان سابقاً (ring + border color)
@@ -72,8 +72,8 @@ export default function ProfileImage({
   })();
 
   if (!disableFrame && frameName && frameIndex) {
-    // مقاسات دقيقة لتطابق الموقع الآخر
-    const px = pixelSize ?? (size === 'small' ? 40 : size === 'large' ? 80 : 64);
+    // مقاسات دقيقة لتطابق الموقع الآخر - مُصغرة بحوالي 10%
+    const px = pixelSize ?? (size === 'small' ? 36 : size === 'large' ? 72 : 56);
     // الحاوية يجب أن تكون أكبر لاستيعاب الإطار (نفس النسبة المستخدمة في VipAvatar)
     const containerSize = px * 1.35;
     return (
@@ -99,7 +99,7 @@ export default function ProfileImage({
         }}
         loading="lazy"
         decoding="async"
-        sizes={size === 'small' ? '40px' : size === 'large' ? '80px' : '64px'}
+        sizes={size === 'small' ? '36px' : size === 'large' ? '72px' : '56px'}
         onError={(e: any) => {
           if (e?.currentTarget && e.currentTarget.src !== '/default_avatar.svg') {
             e.currentTarget.src = '/default_avatar.svg';

--- a/client/src/components/chat/ProfileModal.tsx
+++ b/client/src/components/chat/ProfileModal.tsx
@@ -3182,7 +3182,7 @@ export default function ProfileModal({
                 <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                   <ProfileImage 
                     user={localUser} 
-                    pixelSize={150}
+                    pixelSize={135}
                     hideRoleBadgeOverlay={true}
                     disableFrame={false}
                   />

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -581,7 +581,7 @@ export default function UnifiedSidebar({
                   justifyContent: 'center',
                   flexShrink: 0
                 }}>
-                  <ProfileImage user={user} size="small" pixelSize={40} className="" hideRoleBadgeOverlay={true} />
+                  <ProfileImage user={user} size="small" pixelSize={36} className="" hideRoleBadgeOverlay={true} />
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between gap-2">
@@ -807,7 +807,7 @@ export default function UnifiedSidebar({
                                 <ProfileImage 
                                   user={effectiveUser}
                                   size="small"
-                                  pixelSize={32}
+                                  pixelSize={29}
                                   hideRoleBadgeOverlay={true}
                                 />
                               </div>
@@ -952,7 +952,7 @@ export default function UnifiedSidebar({
                                 <ProfileImage 
                                   user={effectiveUser}
                                   size="small"
-                                  pixelSize={32}
+                                  pixelSize={29}
                                   hideRoleBadgeOverlay={true}
                                 />
                               </div>

--- a/client/src/components/chat/WallPostList.tsx
+++ b/client/src/components/chat/WallPostList.tsx
@@ -123,7 +123,7 @@ export default function WallPostList({
                         <ProfileImage
                           user={effectiveUser}
                           size="small"
-                          pixelSize={40}
+                          pixelSize={36}
                           className=""
                           hideRoleBadgeOverlay={true}
                         />

--- a/client/src/components/ui/RichestModal.tsx
+++ b/client/src/components/ui/RichestModal.tsx
@@ -291,7 +291,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
                       justifyContent: 'center',
                       flexShrink: 0
                     }}>
-                      <ProfileImage user={u} size="small" pixelSize={40} className="" hideRoleBadgeOverlay={true} />
+                      <ProfileImage user={u} size="small" pixelSize={36} className="" hideRoleBadgeOverlay={true} />
                     </div>
                     <div className="flex-1">
                       <div className="flex items-center justify-between gap-2">
@@ -343,7 +343,7 @@ export default function RichestModal({ isOpen, onClose, currentUser, onUserClick
                       justifyContent: 'center',
                       flexShrink: 0
                     }}>
-                      <ProfileImage user={c} size="small" pixelSize={24} className="" hideRoleBadgeOverlay={true} />
+                      <ProfileImage user={c} size="small" pixelSize={22} className="" hideRoleBadgeOverlay={true} />
                     </div>
                     <div className="flex-1">
                       <span className="ac-user-name" style={{ color: getFinalUsernameColor(c) }} title={c.username}>


### PR DESCRIPTION
Slightly reduce the size of profile pictures and their frames across the application to meet a user request for a subtle size reduction (approximately 10%).

---
<a href="https://cursor.com/background-agent?bcId=bc-97fe3f4e-f979-45d4-86cb-3e3e39149cb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-97fe3f4e-f979-45d4-86cb-3e3e39149cb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

