### PR TITLE
Resize frame user container vertically

### DIFF
--- a/client/src/components/chat/MessagesPanel.tsx
+++ b/client/src/components/chat/MessagesPanel.tsx
@@ -379,13 +379,13 @@ export default function MessagesPanel({
                         }}
                       >
                         <div className="flex-shrink-0" style={{ 
-                          width: (user as any)?.profileFrame ? 54 : 40, 
-                          height: (user as any)?.profileFrame ? 54 : 40,
+                          width: (user as any)?.profileFrame ? 48 : 40, 
+                          height: (user as any)?.profileFrame ? 48 : 40,
                           display: 'flex',
                           alignItems: 'center',
                           justifyContent: 'center'
                         }}>
-                          <ProfileImage user={user} size="small" pixelSize={36} hideRoleBadgeOverlay={true} />
+                          <ProfileImage user={user} size="small" pixelSize={32} hideRoleBadgeOverlay={true} />
                         </div>
                         <div className="flex-1 min-w-0 flex flex-col justify-center">
                           <div className="flex items-center justify-between gap-2 w-full">

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -567,21 +567,21 @@ export default function UnifiedSidebar({
               showModerationActions={isModerator}
             >
               <div
-                className={`flex items-center gap-2 ${hasFrame ? 'py-1.5' : 'py-0.5'} px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
+                className={`flex items-center gap-2 ${hasFrame ? 'py-1' : 'py-0.5'} px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
                 style={getUserListItemStyles(user)}
                 onClick={(e) => handleUserClick(e as any, user)}
               >
                 {/* حاوية الصورة - حجم ثابت مع محاذاة مركزية */}
                 <div style={{ 
                   marginLeft: 4, 
-                  width: hasFrame ? 54 : 46,  // تقليل العرض للمستخدمين بدون إطار
-                  height: hasFrame ? 54 : 46, // تقليل الارتفاع للمستخدمين بدون إطار
+                  width: hasFrame ? 48 : 40,  // تقليل العرض للمستخدمين مع الإطار
+                  height: hasFrame ? 48 : 40, // تقليل الارتفاع للمستخدمين مع الإطار
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   flexShrink: 0
                 }}>
-                  <ProfileImage user={user} size="small" pixelSize={36} className="" hideRoleBadgeOverlay={true} />
+                  <ProfileImage user={user} size="small" pixelSize={32} className="" hideRoleBadgeOverlay={true} />
                 </div>
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center justify-between gap-2">
@@ -801,13 +801,13 @@ export default function UnifiedSidebar({
                             } as ChatUser;
                             if (frameFromPost) (effectiveUser as any).profileFrame = frameFromPost;
                             const hasFrame = Boolean((effectiveUser as any)?.profileFrame);
-                            const containerSize = hasFrame ? 43 : 32;
+                            const containerSize = hasFrame ? 38 : 32;
                             return (
                               <div style={{ width: containerSize, height: containerSize, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                                 <ProfileImage 
                                   user={effectiveUser}
                                   size="small"
-                                  pixelSize={29}
+                                  pixelSize={26}
                                   hideRoleBadgeOverlay={true}
                                 />
                               </div>
@@ -946,13 +946,13 @@ export default function UnifiedSidebar({
                             } as ChatUser;
                             if (frameFromPost) (effectiveUser as any).profileFrame = frameFromPost;
                             const hasFrame = Boolean((effectiveUser as any)?.profileFrame);
-                            const containerSize = hasFrame ? 43 : 32;
+                            const containerSize = hasFrame ? 38 : 32;
                             return (
                               <div style={{ width: containerSize, height: containerSize, display: 'flex', alignItems: 'center', justifyContent: 'center', flexShrink: 0 }}>
                                 <ProfileImage 
                                   user={effectiveUser}
                                   size="small"
-                                  pixelSize={29}
+                                  pixelSize={26}
                                   hideRoleBadgeOverlay={true}
                                 />
                               </div>


### PR DESCRIPTION
Reduce container heights for users with frames in user lists, messages, and wall posts to improve compactness and fit.

---
<a href="https://cursor.com/background-agent?bcId=bc-80125f7d-8088-4b20-b950-b4a8972eac2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-80125f7d-8088-4b20-b950-b4a8972eac2a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

