### PR TITLE
Adjust long container height for user list and messages

### DIFF
--- a/client/src/components/chat/MessagesPanel.tsx
+++ b/client/src/components/chat/MessagesPanel.tsx
@@ -317,7 +317,7 @@ export default function MessagesPanel({
         if (!open) onClose();
       }}
     >
-      <DialogContent className="max-w-md max-h-[560px] bg-gradient-to-br from-secondary to-accent border-2 border-accent shadow-2xl overflow-hidden">
+      <DialogContent className="max-w-md max-h-[520px] bg-gradient-to-br from-secondary to-accent border-2 border-accent shadow-2xl overflow-hidden">
         <DialogHeader className="border-b border-accent pb-3">
           <div className="flex items-center justify-center">
             <DialogTitle className="text-xl font-bold text-primary-foreground text-center w-full">
@@ -334,7 +334,7 @@ export default function MessagesPanel({
           </div>
         </DialogHeader>
 
-        <ScrollArea className="h-[460px] w-full">
+        <ScrollArea className="h-[420px] w-full">
           <div className="space-y-4 p-4">
             <section>
               {isLoading ? (

--- a/client/src/components/chat/UserSidebarWithWalls.tsx
+++ b/client/src/components/chat/UserSidebarWithWalls.tsx
@@ -567,7 +567,7 @@ export default function UnifiedSidebar({
               showModerationActions={isModerator}
             >
               <div
-                className={`flex items-center gap-2 ${hasFrame ? 'py-1.5' : 'py-0.5'} px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
+                className={`flex items-center gap-2 ${hasFrame ? 'py-1' : 'py-0.5'} px-1 rounded-none border-b border-border transition-colors duration-200 cursor-pointer w-full ${getUserListItemClasses(user)} hover:bg-accent/10`}
                 style={getUserListItemStyles(user)}
                 onClick={(e) => handleUserClick(e as any, user)}
               >
@@ -613,7 +613,7 @@ export default function UnifiedSidebar({
 
   return (
     <aside
-      className={`w-full bg-sidebar text-sidebar-foreground text-sm overflow-hidden border-l border-sidebar-border shadow-lg flex flex-col h-full max-h-screen ${isMobile ? 'sidebar mobile-scroll' : ''}`}
+      className={`w-full bg-sidebar text-sidebar-foreground text-sm overflow-hidden border-l border-sidebar-border shadow-lg flex flex-col h-full max-h-full ${isMobile ? 'sidebar mobile-scroll' : ''}`}
       style={{ overscrollBehaviorX: 'none' }}
     >
       {/* Top toggle buttons removed; bottom bar is the sole navigation */}


### PR DESCRIPTION
Reduce the vertical height of the user list sidebar and private messages modal to make them more appropriately sized.

The user perceived these containers as too tall and taking up excessive vertical space, requesting a reduction in height without impacting image dimensions.

---
<a href="https://cursor.com/background-agent?bcId=bc-dc5fb858-8b50-4645-be6b-cfc9a64ae148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-dc5fb858-8b50-4645-be6b-cfc9a64ae148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

